### PR TITLE
Rfd updates

### DIFF
--- a/config/jlab-combined-20230526.pem
+++ b/config/jlab-combined-20230526.pem
@@ -1,0 +1,1188 @@
+-----BEGIN CERTIFICATE-----
+MIIDpDCCAoygAwIBAgIESqimDTANBgkqhkiG9w0BAQsFADByMQswCQYDVQQGEwJV
+UzEQMA4GA1UEChMHRW50cnVzdDEiMCAGA1UECxMZQ2VydGlmaWNhdGlvbiBBdXRo
+b3JpdGllczEtMCsGA1UECxMkRW50cnVzdCBNYW5hZ2VkIFNlcnZpY2VzIE5GSSBS
+b290IENBMB4XDTE2MTExNjE2MzEwNFoXDTI3MTIxNjE3MDEwNFowcjELMAkGA1UE
+BhMCVVMxEDAOBgNVBAoTB0VudHJ1c3QxIjAgBgNVBAsTGUNlcnRpZmljYXRpb24g
+QXV0aG9yaXRpZXMxLTArBgNVBAsTJEVudHJ1c3QgTWFuYWdlZCBTZXJ2aWNlcyBO
+RkkgUm9vdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL8fW2c5
+Y1H3DBZcF5uwko+I1N9643gEq3PYUU/AtMzRBJ1PFiipWRNyLYPoVaPYr6GUDsrl
+TyvQ7LJD5uDOFPxWtGggqcDGFPC8u0MBUvqTvjCMBuGwI55vrjfeW4mZfsoGo+qX
+3qHbCRmif/PywciYTnYhArPtM9tZ/9Nyaunpgrk0zKS0G7dgU+aaqW+BQKy8ss6t
+1qbcD5HV5laf6nlTXJ0JrMCbUmuUbhNfCp9e+TwS4LtqjPRL5D/pnUkzURyl2F6/
+53yZ0M51SJy9hxEnTYHd4QmJp3yR2fDEVI7Ug/6RBgyPSjlnWbuDPDArD+G2yzTs
+6tmc1OSDvWYvVUkCAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQF
+MAMBAf8wHQYDVR0OBBYEFPrfIwHEquwj461vDTSlDc85ZGVeMA0GCSqGSIb3DQEB
+CwUAA4IBAQCc5cuNlP+rF3KHR/UOwlNc6YWLxf2ImQ2Zhv+ULPKczx/pZPELHXnz
+kAhTtjpxjpYuH8NHKUxphJEBCL7P7X9zMO66Z5Rso3iwCC95ffYYqJuIxpBn8xuk
+Fm3h6sblYlDiMqbQ4wqtNDPMnlvkBbosp2vsr6V5j5jr1Cp/5e6tKuQuCH8iHq8X
+5kCvImZEzAf8aAH6pRv3pVswCyxBcPzGHMj4N9RrRFBb462+Sk5q1GMA7roajPpR
+Ht7COZNJr2QhWUGSQlavqaaRwYNyeBYuTID8Ihk+VIDdsISQPcor73GMpxK30zym
+fDpTdQ0G0+5XayKnMi2NCLO6EPsLvEJJ
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIGUDCCBTigAwIBAgIERIBi9DANBgkqhkiG9w0BAQsFADBuMQswCQYDVQQGEwJV
+UzEQMA4GA1UEChMHRW50cnVzdDEiMCAGA1UECxMZQ2VydGlmaWNhdGlvbiBBdXRo
+b3JpdGllczEpMCcGA1UECxMgRW50cnVzdCBNYW5hZ2VkIFNlcnZpY2VzIFJvb3Qg
+Q0EwHhcNMTUwNzIzMTYwNjM2WhcNMjUwNzIzMTYzNjM2WjBuMQswCQYDVQQGEwJV
+UzEQMA4GA1UEChMHRW50cnVzdDEiMCAGA1UECxMZQ2VydGlmaWNhdGlvbiBBdXRo
+b3JpdGllczEpMCcGA1UECxMgRW50cnVzdCBNYW5hZ2VkIFNlcnZpY2VzIFJvb3Qg
+Q0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCYqKN6KNw4zYLKgi6Y
+Ooiuw6K/9e/bn7D2gNlAQxPZtGvmvhzIOx2UeHDwhmFkivNy2fgIr85/brQfKguk
+WgpcES9Dl2GpcsnOXDSm+cAtGJrEV6/Ecv6o+z2qm0YRODNEaMF4ANLl/H95yfR4
+l54aI+MX6rxzTnTv+j/QptL3ZyJe8LnQoeIHr69Jo21e6ekGRtlYJ9L8r5qn7s/b
+F9KZ/aksWeB21d1wci3dIIpN5bM8r5YnQLEjjzg35SsbqBEft1/QvgxDbEWTW9/I
+Ij5hWrpyBVe23pJwNtEWluvFxhzQz3xJ0U1ZBRQXySVHbx0k0SyRlhhFv6ricooE
+ThtJAgMBAAGjggL0MIIC8DCCASAGCCsGAQUFBwELBIIBEjCCAQ4wTwYIKwYBBQUH
+MAWGQ2h0dHA6Ly9yb290d2ViLm1hbmFnZWQuZW50cnVzdC5jb20vU0lBL0NBY2Vy
+dHNJc3N1ZWRCeUVNU1Jvb3RDQS5wN2MwgboGCCsGAQUFBzAFhoGtbGRhcDovL3Jv
+b3RkaXIubWFuYWdlZC5lbnRydXN0LmNvbS9vdT1FbnRydXN0JTIwTWFuYWdlZCUy
+MFNlcnZpY2VzJTIwUm9vdCUyMENBLG91PUNlcnRpZmljYXRpb24lMjBBdXRob3Jp
+dGllcyxvPUVudHJ1c3QsYz1VUz9jQUNlcnRpZmljYXRlO2JpbmFyeSxjcm9zc0Nl
+cnRpZmljYXRlUGFpcjtiaW5hcnkwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8E
+BAMCAQYwggGIBgNVHR8EggF/MIIBezCB7qCB66CB6IY2aHR0cDovL3Jvb3R3ZWIu
+bWFuYWdlZC5lbnRydXN0LmNvbS9DUkxzL0VNU1Jvb3RDQTIuY3JshoGtbGRhcDov
+L3Jvb3RkaXIubWFuYWdlZC5lbnRydXN0LmNvbS9jbj1XaW5Db21iaW5lZDIsb3U9
+RW50cnVzdCUyME1hbmFnZWQlMjBTZXJ2aWNlcyUyMFJvb3QlMjBDQSxvdT1DZXJ0
+aWZpY2F0aW9uJTIwQXV0aG9yaXRpZXMsbz1FbnRydXN0LGM9VVM/Y2VydGlmaWNh
+dGVSZXZvY2F0aW9uTGlzdDtiaW5hcnkwgYeggYSggYGkfzB9MQswCQYDVQQGEwJV
+UzEQMA4GA1UEChMHRW50cnVzdDEiMCAGA1UECxMZQ2VydGlmaWNhdGlvbiBBdXRo
+b3JpdGllczEpMCcGA1UECxMgRW50cnVzdCBNYW5hZ2VkIFNlcnZpY2VzIFJvb3Qg
+Q0ExDTALBgNVBAMTBENSTDEwHQYDVR0OBBYEFKlTvmSEg0tdJsYnPi7RhGhVPNB1
+MA0GCSqGSIb3DQEBCwUAA4IBAQBEML+28I4774Ljsi9UQVuiJ8rMn3vWxqhSgrWh
+OTSKEgHgmqAAz/DSwk9lWSt3MKhXsIYiudW7paB4hIxvPurpOYp1iOTn2JesPOKN
+cV865auh+LFr/wBGDYlUMr/X0jnmFVqHHGBn5Ev5OgpWx0x6YDp0PvUFNAzNMNHi
+63epqJd9aNwau7oWQqtvW38I1fZzdT/bd3B3zBtJRpbjiJVEeaX6SUXrMT2noMsN
+2vBWo++6XpnB7LUPMx5nZQ/EIF1+s7NmX6xjxU8qBOjPLG/lvVf+1bJ1RbmhYXnH
+yc374GfU6KTMBfB4hR6pet7+PgFtXubRd0zI7O9gqiwQgZpU
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIE1zCCA7+gAwIBAgIERIEHejANBgkqhkiG9w0BAQsFADBuMQswCQYDVQQGEwJV
+UzEQMA4GA1UEChMHRW50cnVzdDEiMCAGA1UECxMZQ2VydGlmaWNhdGlvbiBBdXRo
+b3JpdGllczEpMCcGA1UECxMgRW50cnVzdCBNYW5hZ2VkIFNlcnZpY2VzIFJvb3Qg
+Q0EwHhcNMTkwODEzMTM1MDM4WhcNMjkwODEzMTQyMDM4WjBuMQswCQYDVQQGEwJV
+UzEQMA4GA1UEChMHRW50cnVzdDEiMCAGA1UECxMZQ2VydGlmaWNhdGlvbiBBdXRo
+b3JpdGllczEpMCcGA1UECxMgRW50cnVzdCBNYW5hZ2VkIFNlcnZpY2VzIFJvb3Qg
+Q0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDnvaBqgVvvj6CwJ4yu
+Wifd2/mmMsnJTicI7RCqJKHNcrxmqDA1rjvP4p0XfDWh95HFiy7SqD/qDOVBTmzU
+NuUbwJ42xdejCNpjAMAyiwNJHgeuwu22vUL/jHEuQp6NfgZDTWSlMdYx6O2mKgYw
+fcWqAr4T0ZruEZT2uDLQJ5Uzb8ugnd6S3frF2md0IRtR973JAiWIQgJslsqHFwx5
+skoA5vqDyPKvQLN4pecOrBUxQSfhEQOxXFCATOZAyvJZ2v8sFlyRLjQAQSFzgPWi
+O2ywAG8qtv03OkadII9IMVcVjw3kL74KYDY6Flpk4eD/+nzk8TFvgBUGbJlx4hrL
+XB7NAgMBAAGjggF7MIIBdzBfBggrBgEFBQcBCwRTMFEwTwYIKwYBBQUHMAWGQ2h0
+dHA6Ly9yb290d2ViLm1hbmFnZWQuZW50cnVzdC5jb20vU0lBL0NBY2VydHNJc3N1
+ZWRCeUVNU1Jvb3RDQS5wN2MwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMC
+AYYwgdMGA1UdHwSByzCByDA8oDqgOIY2aHR0cDovL3Jvb3R3ZWIubWFuYWdlZC5l
+bnRydXN0LmNvbS9DUkxzL0VNU1Jvb3RDQTMuY3JsMIGHoIGEoIGBpH8wfTELMAkG
+A1UEBhMCVVMxEDAOBgNVBAoTB0VudHJ1c3QxIjAgBgNVBAsTGUNlcnRpZmljYXRp
+b24gQXV0aG9yaXRpZXMxKTAnBgNVBAsTIEVudHJ1c3QgTWFuYWdlZCBTZXJ2aWNl
+cyBSb290IENBMQ0wCwYDVQQDEwRDUkwxMB0GA1UdDgQWBBRJVJFMaUQ7xPgCLPT4
+LTNWiXWYEDANBgkqhkiG9w0BAQsFAAOCAQEAffgN0+kDAHMFnNkEFPJdXHYojaAw
+jvsyb4rFUXhOv/QPl0lOSUevqJpPyFsVutEM4Jk6NU68FjZv8EWDvWrUw2VtxI7/
+fVlu18SDXcpsvvnFSnGxIsJLYce5Jnwmox/E0eaZnqEXwGoVXglvjXY3dEL08BgV
+wQcMd3fx5ldj11nQ+p07PQ6EZrg/xxwsDM/vjI2Wd7eDV1PN10UDJS7T24sWCK8g
+Nk8Fh2588LSU+B1HVHtA7Js2kNJronU1X0S09lNLJ38LRRhQ4IXiLlTaC9rr3S0f
+gWY6jRJq6riIfZN0ywR0wTzXZqBJLcW4Vnav8k8bjlYxEL4A3Umr1mHSoA==
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIFKTCCBBGgAwIBAgICc0owDQYJKoZIhvcNAQELBQAwWTELMAkGA1UEBhMCVVMx
+GDAWBgNVBAoTD1UuUy4gR292ZXJubWVudDENMAsGA1UECxMERlBLSTEhMB8GA1UE
+AxMYRmVkZXJhbCBDb21tb24gUG9saWN5IENBMB4XDTE5MDgxNDE1Mzk0NloXDTI5
+MDgxNDE1MzY0MlowbjELMAkGA1UEBhMCVVMxEDAOBgNVBAoTB0VudHJ1c3QxIjAg
+BgNVBAsTGUNlcnRpZmljYXRpb24gQXV0aG9yaXRpZXMxKTAnBgNVBAsTIEVudHJ1
+c3QgTWFuYWdlZCBTZXJ2aWNlcyBSb290IENBMIIBIjANBgkqhkiG9w0BAQEFAAOC
+AQ8AMIIBCgKCAQEA572gaoFb74+gsCeMrlon3dv5pjLJyU4nCO0QqiShzXK8Zqgw
+Na47z+KdF3w1ofeRxYsu0qg/6gzlQU5s1DblG8CeNsXXowjaYwDAMosDSR4HrsLt
+tr1C/4xxLkKejX4GQ01kpTHWMejtpioGMH3FqgK+E9Ga7hGU9rgy0CeVM2/LoJ3e
+kt36xdpndCEbUfe9yQIliEICbJbKhxcMebJKAOb6g8jyr0CzeKXnDqwVMUEn4RED
+sVxQgEzmQMryWdr/LBZckS40AEEhc4D1ojtssABvKrb9NzpGnSCPSDFXFY8N5C++
+CmA2OhZaZOHg//p85PExb4AVBmyZceIay1wezQIDAQABo4IB5DCCAeAwDwYDVR0T
+AQH/BAUwAwEB/zBPBggrBgEFBQcBAQRDMEEwPwYIKwYBBQUHMAKGM2h0dHA6Ly9o
+dHRwLmZwa2kuZ292L2ZjcGNhL2NhQ2VydHNJc3N1ZWRUb2ZjcGNhLnA3YzAPBgNV
+HSQECDAGgAEAgQEAMAoGA1UdNgQDAgEAMHkGA1UdIARyMHAwDAYKYIZIAWUDAgED
+BjAMBgpghkgBZQMCAQMHMAwGCmCGSAFlAwIBAwgwDAYKYIZIAWUDAgEDDTAMBgpg
+hkgBZQMCAQMRMAwGCmCGSAFlAwIBAycwDAYKYIZIAWUDAgEDKDAMBgpghkgBZQMC
+AQMpMF0GCCsGAQUFBwELBFEwTzBNBggrBgEFBQcwBYZBaHR0cDovL3Jvb3R3ZWIu
+bWFuYWdlZC5lbnRydXN0LmNvbS9TSUEvQ2VydHNJc3N1ZWRCeUVNU1Jvb3RDQS5w
+N2MwDgYDVR0PAQH/BAQDAgGGMB8GA1UdIwQYMBaAFK0MenVc5fOYxHmYDqwo/Zf0
+5wL8MDUGA1UdHwQuMCwwKqAooCaGJGh0dHA6Ly9odHRwLmZwa2kuZ292L2ZjcGNh
+L2ZjcGNhLmNybDAdBgNVHQ4EFgQUSVSRTGlEO8T4Aiz0+C0zVol1mBAwDQYJKoZI
+hvcNAQELBQADggEBAMX/TfukCGAdHdlIuDuBG3wg5+GIRzf5Vgt/gEl+dNR3BdVO
+FrA+yKdPwnV9A+HZtxwC6YrIgxHsD8iImvF6WCuDWwNl2mNg0AynC3FNfyJlzMCw
+kPbs2n4VqmcaP5hqVCiKVv+omQ7CwRM18ms4Ia0oHNFCaV3yvZb/QMFKUM3CaK0s
+qZNmmBAqf6+XVeha45kKNtI20HXhUBzGyvmo/3vNfzJTQIQMqV10QP5ectlFvlLv
+TjP+7mNJvuo3M5avGucbsNQLZrGsQMgIVcdhc4Juf3cklUNDJxAiyFbX3LEcP2SD
++6w/aYn9eB1GK8AqFv1dNfMK5dKBmrDRhMmxIqg=
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIG3DCCBMSgAwIBAgIUIV542ZZIsCHGOUplZtjgD0ah5ZUwDQYJKoZIhvcNAQEM
+BQAwXDELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD1UuUy4gR292ZXJubWVudDENMAsG
+A1UECxMERlBLSTEkMCIGA1UEAxMbRmVkZXJhbCBDb21tb24gUG9saWN5IENBIEcy
+MB4XDTIwMTExODE0MzAzNFoXDTI5MDgxNDEzMzAzNFowbjELMAkGA1UEBhMCVVMx
+EDAOBgNVBAoTB0VudHJ1c3QxIjAgBgNVBAsTGUNlcnRpZmljYXRpb24gQXV0aG9y
+aXRpZXMxKTAnBgNVBAsTIEVudHJ1c3QgTWFuYWdlZCBTZXJ2aWNlcyBSb290IENB
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA572gaoFb74+gsCeMrlon
+3dv5pjLJyU4nCO0QqiShzXK8ZqgwNa47z+KdF3w1ofeRxYsu0qg/6gzlQU5s1Dbl
+G8CeNsXXowjaYwDAMosDSR4HrsLttr1C/4xxLkKejX4GQ01kpTHWMejtpioGMH3F
+qgK+E9Ga7hGU9rgy0CeVM2/LoJ3ekt36xdpndCEbUfe9yQIliEICbJbKhxcMebJK
+AOb6g8jyr0CzeKXnDqwVMUEn4REDsVxQgEzmQMryWdr/LBZckS40AEEhc4D1ojts
+sABvKrb9NzpGnSCPSDFXFY8N5C++CmA2OhZaZOHg//p85PExb4AVBmyZceIay1we
+zQIDAQABo4ICgjCCAn4wHQYDVR0OBBYEFElUkUxpRDvE+AIs9PgtM1aJdZgQMB8G
+A1UdIwQYMBaAFPQnXKnDfEf0+qansFmXqt01JhfjMA4GA1UdDwEB/wQEAwIBBjAP
+BgNVHRMBAf8EBTADAQH/MIGzBgNVHSAEgaswgagwDAYKYIZIAWUDAgEDEjAMBgpg
+hkgBZQMCAQMTMAwGCmCGSAFlAwIBAxQwDAYKYIZIAWUDAgEDBjAMBgpghkgBZQMC
+AQMHMAwGCmCGSAFlAwIBAwgwDAYKYIZIAWUDAgEDJDAMBgpghkgBZQMCAQMNMAwG
+CmCGSAFlAwIBAxEwDAYKYIZIAWUDAgEDJzAMBgpghkgBZQMCAQMoMAwGCmCGSAFl
+AwIBAykwXQYIKwYBBQUHAQsEUTBPME0GCCsGAQUFBzAFhkFodHRwOi8vcm9vdHdl
+Yi5tYW5hZ2VkLmVudHJ1c3QuY29tL1NJQS9DZXJ0c0lzc3VlZEJ5RU1TUm9vdENB
+LnA3YzASBgNVHSQBAf8ECDAGgAEAgQEAMA0GA1UdNgEB/wQDAgEAMFEGCCsGAQUF
+BwEBBEUwQzBBBggrBgEFBQcwAoY1aHR0cDovL3JlcG8uZnBraS5nb3YvZmNwY2Ev
+Y2FDZXJ0c0lzc3VlZFRvZmNwY2FnMi5wN2MwNwYDVR0fBDAwLjAsoCqgKIYmaHR0
+cDovL3JlcG8uZnBraS5nb3YvZmNwY2EvZmNwY2FnMi5jcmwwVwYDVR0hBFAwTjAY
+BgpghkgBZQMCAQMSBgpghkgBZQMCAQMtMBgGCmCGSAFlAwIBAxMGCmCGSAFlAwIB
+Ay4wGAYKYIZIAWUDAgEDFAYKYIZIAWUDAgEDLzANBgkqhkiG9w0BAQwFAAOCAgEA
+v65FJeNH7H2AjfuaAa2kNJGBI+QaltbncrWbISA31sateJabjnocyW1TfbtQUzls
+iATk5p8RaT+LPRVRNs/4TtYs6XkhItOYMIcNkBk8jc+4xKMR8GXA/sPfZa7Wo7Vk
+1TcNMdO2DZtEumaH94zq/CtLbyzBNHj4N5hZyE9S/lX2JAVzRFuNjsgbEgza7+q2
+WNb5oo8JKRFJNUTh9KvFpmHOeqyngGivIzLvc0w61mV9ZPAqKYdS59ZD2b91LKIF
+Ar2CBGhwrY5Mj/VTIRdklPa7cPcXumCWgBCtln7LlhPrxg7OTDvvRDjt6aHJuRn4
+lesOHpbgiaQWxUBrfD/id7tLacEpvWNZR3wENnU805LHAk2GvNvjzXelhgAfr81G
+SxCX8gw0paZHotoh5zWuHksBwCAoDIQePW738hp0NQc3KsaWxMZyuXFt4EuchW7T
+jpAIiiDjvqg5t2z7+xfpEm5TegTg8d9dsqw0Jch4xOGqrqmM0SvR7+dRUthESnUM
+aKacVOlrorHt31s+lNjLrnPHc3F8YPzC1Q+0ftxVoqugK+O0wxSlmlxew1J2tKdi
+W58yw5u2mtzO0WNj1gUuvyUfw33AQ88nZCgtNUWrponvTf7onW+RcEJv+N/6JyYm
+DIp+1qtsrtLmwAoNfe/KAKBWumEv5d0EqR8jWoFfJ0I=
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIHQTCCBimgAwIBAgIERIBj1TANBgkqhkiG9w0BAQsFADBuMQswCQYDVQQGEwJV
+UzEQMA4GA1UEChMHRW50cnVzdDEiMCAGA1UECxMZQ2VydGlmaWNhdGlvbiBBdXRo
+b3JpdGllczEpMCcGA1UECxMgRW50cnVzdCBNYW5hZ2VkIFNlcnZpY2VzIFJvb3Qg
+Q0EwHhcNMTUwNzMwMTYzNzQ0WhcNMjUwNzIzMTYzNjM2WjBtMQswCQYDVQQGEwJV
+UzEQMA4GA1UEChMHRW50cnVzdDEiMCAGA1UECxMZQ2VydGlmaWNhdGlvbiBBdXRo
+b3JpdGllczEoMCYGA1UECxMfRW50cnVzdCBNYW5hZ2VkIFNlcnZpY2VzIFNTUCBD
+QTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOAWps85AHSHa7h8Mra/
+tS//OaO6Pj4sokxbJc9rYvfzSeevJDw13zwuayYX9eSxJqC7vyevCNr+Et8zm3F2
+LJnu66D1e5nVj5HqQtp5fhn3jse1M5aicFuQuZbQNvejxZ+dpzuwmJ/56eRwLcRt
+ts6N7vu4+lqhftXM7ItNzeJJ9buOk6G6J2QMRedU5kotAEapPUdZ4f7moc4LYVa0
+g2wCa0FCLf24q9gvg4Qm0kYWz1eCYrXuGRbIX2H1I2duF5alv/ebPNB7hkmXdFIy
+neJrdBRvt0T+7UmH4Emy/Jda5S22PM1UOtmG9Qbqo9rpOmU4LRomPrPtJPvuY0CP
+IQECAwEAAaOCA+YwggPiMA4GA1UdDwEB/wQEAwIBBjCBiAYDVR0gBIGAMH4wDAYK
+YIZIAWUDAgEDBjAMBgpghkgBZQMCAQMHMAwGCmCGSAFlAwIBAwgwDAYKYIZIAWUD
+AgEDDTAMBgpghkgBZQMCAQMRMAwGCmCGSAFlAwIBAyQwDAYKYIZIAWUDAgEDJzAM
+BgpghkgBZQMCAQMoMAwGCmCGSAFlAwIBAykwEgYDVR0TAQH/BAgwBgEB/wIBADCC
+AWMGCCsGAQUFBwEBBIIBVTCCAVEwTQYIKwYBBQUHMAKGQWh0dHA6Ly9yb290d2Vi
+Lm1hbmFnZWQuZW50cnVzdC5jb20vQUlBL0NlcnRzSXNzdWVkVG9FTVNSb290Q0Eu
+cDdjMIG6BggrBgEFBQcwAoaBrWxkYXA6Ly9yb290ZGlyLm1hbmFnZWQuZW50cnVz
+dC5jb20vb3U9RW50cnVzdCUyME1hbmFnZWQlMjBTZXJ2aWNlcyUyMFJvb3QlMjBD
+QSxvdT1DZXJ0aWZpY2F0aW9uJTIwQXV0aG9yaXRpZXMsbz1FbnRydXN0LGM9VVM/
+Y0FDZXJ0aWZpY2F0ZTtiaW5hcnksY3Jvc3NDZXJ0aWZpY2F0ZVBhaXI7YmluYXJ5
+MEMGCCsGAQUFBzABhjdodHRwOi8vb2NzcC5tYW5hZ2VkLmVudHJ1c3QuY29tL09D
+U1AvRU1TUm9vdENBUmVzcG9uZGVyMIIBiAYDVR0fBIIBfzCCAXswge6ggeuggeiG
+Nmh0dHA6Ly9yb290d2ViLm1hbmFnZWQuZW50cnVzdC5jb20vQ1JMcy9FTVNSb290
+Q0EyLmNybIaBrWxkYXA6Ly9yb290ZGlyLm1hbmFnZWQuZW50cnVzdC5jb20vY249
+V2luQ29tYmluZWQyLG91PUVudHJ1c3QlMjBNYW5hZ2VkJTIwU2VydmljZXMlMjBS
+b290JTIwQ0Esb3U9Q2VydGlmaWNhdGlvbiUyMEF1dGhvcml0aWVzLG89RW50cnVz
+dCxjPVVTP2NlcnRpZmljYXRlUmV2b2NhdGlvbkxpc3Q7YmluYXJ5MIGHoIGEoIGB
+pH8wfTELMAkGA1UEBhMCVVMxEDAOBgNVBAoTB0VudHJ1c3QxIjAgBgNVBAsTGUNl
+cnRpZmljYXRpb24gQXV0aG9yaXRpZXMxKTAnBgNVBAsTIEVudHJ1c3QgTWFuYWdl
+ZCBTZXJ2aWNlcyBSb290IENBMQ0wCwYDVQQDEwRDUkwxMB8GA1UdIwQYMBaAFKlT
+vmSEg0tdJsYnPi7RhGhVPNB1MB0GA1UdDgQWBBRVtGwzP+NgGqf/w+209+QE2inQ
+YzANBgkqhkiG9w0BAQsFAAOCAQEAHQpB8fe6Cj/DlsRBnP7AKqhR2UFEF+pOFXec
+SIP5R3B8cVz9ippRiZrLFdnVfvAjj3xEQAxqTJlLNVjcNGtHuvklhmebsXlCEoHm
+grRYuAoAyhu92IyQ1+cq77mOlpVbmE6AsXsUvh9zBTlavsXJ0RhfQ49JJD6nPuda
+rO8Dl6ehTFpxpzEqhieGso4XDu3tLl3Z6kOe2Hgfp9CdEf7rRjJPdLpv/RFGPbsx
+YJ7V4c1ryxnbCP0IDF8zw0Ocuw08tvtP4YdSid+FcR7PoGqKXBUdOJR6GwIP6n3F
+FVgoq2/4mMrZ1ZDmz2mbS/O6xdllRc99aHA9MHvbq/EpE5dr3g==
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIFuzCCBKOgAwIBAgIERIEHtjANBgkqhkiG9w0BAQsFADBuMQswCQYDVQQGEwJV
+UzEQMA4GA1UEChMHRW50cnVzdDEiMCAGA1UECxMZQ2VydGlmaWNhdGlvbiBBdXRo
+b3JpdGllczEpMCcGA1UECxMgRW50cnVzdCBNYW5hZ2VkIFNlcnZpY2VzIFJvb3Qg
+Q0EwHhcNMTkwODEzMTU0NjI5WhcNMjkwNzEzMTYxNjI5WjBtMQswCQYDVQQGEwJV
+UzEQMA4GA1UEChMHRW50cnVzdDEiMCAGA1UECxMZQ2VydGlmaWNhdGlvbiBBdXRo
+b3JpdGllczEoMCYGA1UECxMfRW50cnVzdCBNYW5hZ2VkIFNlcnZpY2VzIFNTUCBD
+QTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANjtFQkAPFlMQRrHGBGI
+zgXekI4wz+uu+neolkME7eAh+bBOopDwZkrp+TO/r9H1YLpvSmphwd7RBE6sWQEn
+Fbez48ZY6V0PND8j13DEqO7ODIA4KHGmomuF3CFxjC5wYgpT0dPrSkMwmc4dr2xs
+7801L1ekJj8+eybcZVd+45ok4283sgyn0cVDzV1w5WOg0lhWz7CwuWhNOh1ZeZi3
+1T49i9ETppBF86GR05UlBlaPBgUO85t9asxIrj8ejIWW89EVTtsnZ3r5SOkKtojP
+QMEM88RHqwkiBMyEtftSc3LvkJgcQWXQ+0c4zMOjMDZD/4yn69dg8OWTsuXjw0qi
+n/cCAwEAAaOCAmAwggJcMA4GA1UdDwEB/wQEAwIBhjB5BgNVHSAEcjBwMAwGCmCG
+SAFlAwIBAwYwDAYKYIZIAWUDAgEDBzAMBgpghkgBZQMCAQMIMAwGCmCGSAFlAwIB
+Aw0wDAYKYIZIAWUDAgEDETAMBgpghkgBZQMCAQMnMAwGCmCGSAFlAwIBAygwDAYK
+YIZIAWUDAgEDKTASBgNVHRMBAf8ECDAGAQH/AgEAMIGkBggrBgEFBQcBAQSBlzCB
+lDBNBggrBgEFBQcwAoZBaHR0cDovL3Jvb3R3ZWIubWFuYWdlZC5lbnRydXN0LmNv
+bS9BSUEvQ2VydHNJc3N1ZWRUb0VNU1Jvb3RDQS5wN2MwQwYIKwYBBQUHMAGGN2h0
+dHA6Ly9vY3NwLm1hbmFnZWQuZW50cnVzdC5jb20vT0NTUC9FTVNSb290Q0FSZXNw
+b25kZXIwgdMGA1UdHwSByzCByDA8oDqgOIY2aHR0cDovL3Jvb3R3ZWIubWFuYWdl
+ZC5lbnRydXN0LmNvbS9DUkxzL0VNU1Jvb3RDQTMuY3JsMIGHoIGEoIGBpH8wfTEL
+MAkGA1UEBhMCVVMxEDAOBgNVBAoTB0VudHJ1c3QxIjAgBgNVBAsTGUNlcnRpZmlj
+YXRpb24gQXV0aG9yaXRpZXMxKTAnBgNVBAsTIEVudHJ1c3QgTWFuYWdlZCBTZXJ2
+aWNlcyBSb290IENBMQ0wCwYDVQQDEwRDUkwxMB8GA1UdIwQYMBaAFElUkUxpRDvE
++AIs9PgtM1aJdZgQMB0GA1UdDgQWBBTm3RoHGstruiC5ljmT+BTcmAM3JzANBgkq
+hkiG9w0BAQsFAAOCAQEA1zN6YX5CcwAqUOYGU7QQ4QIZaZvpnTN/KDEYHGDIhTYS
+KlkAXz0ncwe5P3V9YfnF+UwDJFwBZVtzxIy+2lIbEvkkIezYKwJm6K2PHweePL6E
+WpCaVhe39WrOo3LRjKIWO+Lp502Rkb/cBJVG2M2OE1ve4Ydt5GlPWXXi1uGoHJHW
+U8jc2aPDIK5KTCtzh2tfEG6dkjykPosx5ZwNjcZ8IkTFoIh7hsLxniu8kHhOd2k0
+6nM+ctNiBdl2nCQ7GpDSJaL+1MJsXkVjav8ZCBRL9CXwAZSodu2RpkSuNSwrmLmw
+V0lxFBzM+0lGoM8FlV31siMrQBoi0pjDgSjkkJFMFA==
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIH6DCCBtCgAwIBAgIESqi56jANBgkqhkiG9w0BAQsFADByMQswCQYDVQQGEwJV
+UzEQMA4GA1UEChMHRW50cnVzdDEiMCAGA1UECxMZQ2VydGlmaWNhdGlvbiBBdXRo
+b3JpdGllczEtMCsGA1UECxMkRW50cnVzdCBNYW5hZ2VkIFNlcnZpY2VzIE5GSSBS
+b290IENBMB4XDTE3MDUxNjE0MzEzNVoXDTI3MTExNjE1MDEzNVowcTELMAkGA1UE
+BhMCVVMxEDAOBgNVBAoTB0VudHJ1c3QxIjAgBgNVBAsTGUNlcnRpZmljYXRpb24g
+QXV0aG9yaXRpZXMxLDAqBgNVBAsTI0VudHJ1c3QgTkZJIE1lZGl1bSBBc3N1cmFu
+Y2UgU1NQIENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoOEqao5H
+z2toLgtRAaca84ZyEuQ9QVpZ1RdJEHkFZpLnfx396cjx7ZlwUfmeo41l8NVsgZh8
+AVnSdZQLU1rT3Lf2j+4vvHDGhtWTGKQM22obX6n/j1nk66JA6U0pANIWnuHQ9APr
+10IugCpVIoYfVWXvuj+Jj8NJKehUdDfv1L3SZwW/KE9Osuadjx+y+jZ3d87Y+8r8
+rzmKggqNxrE+xBVpRFxYyVMtWcooAG6YyO7Arp3BlufephNWOjzYr3TCCJyjk02F
+yxTlf9WqfhDNguAFGhbL97NRZPKpRLcEc6gHI8VBtGdP+BiDx/c8Kn0tTf3I41yB
+jMZ6h7I66502sQIDAQABo4IEhTCCBIEwDgYDVR0PAQH/BAQDAgEGMIIBHQYDVR0g
+BIIBFDCCARAwDwYNYIZIAYb6a4FIAwoHATAPBg1ghkgBhvprgUgDCgcCMA8GDWCG
+SAGG+muBSAMKBwMwDwYNYIZIAYb6a4FIAwoHBDAPBg1ghkgBhvprgUgDCgcFMA8G
+DWCGSAGG+muBSAMKBwYwDwYNYIZIAYb6a4FIAwoHBzAPBg1ghkgBhvprgUgDCgcI
+MA8GDWCGSAGG+muBSAMKBwkwDwYNYIZIAYb6a4FIAwoHCjAPBg1ghkgBhvprgUgD
+CgcLMA8GDWCGSAGG+muBSAMKBwwwDwYNYIZIAYb6a4FIAwoHDTAPBg1ghkgBhvpr
+gUgDCgcOMA8GDWCGSAGG+muBSAMKBw8wDwYNYIZIAYb6a4FIAwoHEDASBgNVHRMB
+Af8ECDAGAQH/AgEAMIIBWgYIKwYBBQUHAQEEggFMMIIBSDBQBggrBgEFBQcwAoZE
+aHR0cDovL25maXJvb3R3ZWIubWFuYWdlZC5lbnRydXN0LmNvbS9BSUEvQ2VydHNJ
+c3N1ZWRUb05GSVJvb3RDQS5wN2MwgcMGCCsGAQUFBzAChoG2bGRhcDovL25maXJv
+b3RkaXIubWFuYWdlZC5lbnRydXN0LmNvbS9vdT1FbnRydXN0JTIwTWFuYWdlZCUy
+MFNlcnZpY2VzJTIwTkZJJTIwUm9vdCUyMENBLG91PUNlcnRpZmljYXRpb24lMjBB
+dXRob3JpdGllcyxvPUVudHJ1c3QsYz1VUz9jQUNlcnRpZmljYXRlO2JpbmFyeSxj
+cm9zc0NlcnRpZmljYXRlUGFpcjtiaW5hcnkwLgYIKwYBBQUHMAGGImh0dHA6Ly9u
+ZmlvY3NwLm1hbmFnZWQuZW50cnVzdC5jb20wggGaBgNVHR8EggGRMIIBjTCB+qCB
+96CB9IY5aHR0cDovL25maXJvb3R3ZWIubWFuYWdlZC5lbnRydXN0LmNvbS9DUkxz
+L05GSVJvb3RDQTIuY3JshoG2bGRhcDovL25maXJvb3RkaXIubWFuYWdlZC5lbnRy
+dXN0LmNvbS9jbj1XaW5Db21iaW5lZDIsb3U9RW50cnVzdCUyME1hbmFnZWQlMjBT
+ZXJ2aWNlcyUyME5GSSUyMFJvb3QlMjBDQSxvdT1DZXJ0aWZpY2F0aW9uJTIwQXV0
+aG9yaXRpZXMsbz1FbnRydXN0LGM9VVM/Y2VydGlmaWNhdGVSZXZvY2F0aW9uTGlz
+dDtiaW5hcnkwgY2ggYqggYekgYQwgYExCzAJBgNVBAYTAlVTMRAwDgYDVQQKEwdF
+bnRydXN0MSIwIAYDVQQLExlDZXJ0aWZpY2F0aW9uIEF1dGhvcml0aWVzMS0wKwYD
+VQQLEyRFbnRydXN0IE1hbmFnZWQgU2VydmljZXMgTkZJIFJvb3QgQ0ExDTALBgNV
+BAMTBENSTDEwHwYDVR0jBBgwFoAU+t8jAcSq7CPjrW8NNKUNzzlkZV4wHQYDVR0O
+BBYEFGb5JZiuy/vhjACEGdSF/5NW6tamMA0GCSqGSIb3DQEBCwUAA4IBAQAYzB20
+TFlb/g4Q/l+evqW05L9MxsayCR+sCXxpi4CtYgeAxWGTTLIUbbRj7vWPGC/aanWr
+Was8mRYsJSQRy3SGZJ0cG8bkheIe4Tqm6ALmw2DRaaolDKSJ6yQ+LART0C+Oi8IY
+k5BcM6hLpQlm/30UYtvA53AiwTMJVClb7QK+e//4Z0wnDD23PdQXWiUQE9q4+vz3
+L+ifgFEljY6EqdKT6dlZVl16xt5gZrrdFlsblPZxuvnnmgl88/qwMd2zfcKTIanP
+M+llQt6jM2L3C+PTOBALt9XZyq3Qw1RLfQWsaNcs0/fDOoJfHHw0r9QmMLrBpWJp
+7pVxA2WkITMFclBt
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIEYDCCA0igAwIBAgICATAwDQYJKoZIhvcNAQELBQAwWTELMAkGA1UEBhMCVVMx
+GDAWBgNVBAoTD1UuUy4gR292ZXJubWVudDENMAsGA1UECxMERlBLSTEhMB8GA1UE
+AxMYRmVkZXJhbCBDb21tb24gUG9saWN5IENBMB4XDTEwMTIwMTE2NDUyN1oXDTMw
+MTIwMTE2NDUyN1owWTELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD1UuUy4gR292ZXJu
+bWVudDENMAsGA1UECxMERlBLSTEhMB8GA1UEAxMYRmVkZXJhbCBDb21tb24gUG9s
+aWN5IENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2HX7NRY0WkG/
+Wq9cMAQUHK14RLXqJup1YcfNNnn4fNi9KVFmWSHjeavUeL6wLbCh1bI1FiPQzB6+
+Duir3MPJ1hLXp3JoGDG4FyKyPn66CG3G/dFYLGmgA/Aqo/Y/ISU937cyxY4nsyOl
+4FKzXZbpsLjFxZ+7xaBugkC7xScFNknWJidpDDSPzyd6KgqjQV+NHQOGgxXgVcHF
+mCye7Bpy3EjBPvmE0oSCwRvDdDa3ucc2Mnr4MrbQNq4iGDGMUHMhnv6DOzCIJOPp
+wX7e7ZjHH5IQip9bYi+dpLzVhW86/clTpyBLqtsgqyFOHQ1O5piF5asRR12dP8Qj
+wOMUBm7+nQIDAQABo4IBMDCCASwwDwYDVR0TAQH/BAUwAwEB/zCB6QYIKwYBBQUH
+AQsEgdwwgdkwPwYIKwYBBQUHMAWGM2h0dHA6Ly9odHRwLmZwa2kuZ292L2ZjcGNh
+L2NhQ2VydHNJc3N1ZWRCeWZjcGNhLnA3YzCBlQYIKwYBBQUHMAWGgYhsZGFwOi8v
+bGRhcC5mcGtpLmdvdi9jbj1GZWRlcmFsJTIwQ29tbW9uJTIwUG9saWN5JTIwQ0Es
+b3U9RlBLSSxvPVUuUy4lMjBHb3Zlcm5tZW50LGM9VVM/Y0FDZXJ0aWZpY2F0ZTti
+aW5hcnksY3Jvc3NDZXJ0aWZpY2F0ZVBhaXI7YmluYXJ5MA4GA1UdDwEB/wQEAwIB
+BjAdBgNVHQ4EFgQUrQx6dVzl85jEeZgOrCj9l/TnAvwwDQYJKoZIhvcNAQELBQAD
+ggEBAI9z2uF/gLGH9uwsz9GEYx728Yi3mvIRte9UrYpuGDco71wb5O9Qt2wmGCMi
+TR0mRyDpCZzicGJxqxHPkYnos/UqoEfAFMtOQsHdDA4b8Idb7OV316rgVNdF9IU+
+7LQd3nyKf1tNnJaK0KIyn9psMQz4pO9+c+iR3Ah6cFqgr2KBWfgAdKLI3VTKQVZH
+venAT+0g3eOlCd+uKML80cgX2BLHb94u6b2akfI8WpQukSKAiaGMWMyDeiYZdQKl
+Dn0KJnNR6obLB6jI/WNaNZvSr79PMUjBhHDbNXuaGQ/lj/RqDG8z2esccKIN47lQ
+A2EC/0rskqTcLe4qNJMHtyznGI8=
+-----END CERTIFICATE-----
+0Ç›0Ç≈†!Âπ†Ãïm‚x +®˝≈äò≥˚Í0	*ÜHÜ˜ 0\10	UUS10U
+U.S. Government10UFPKI1$0"UFederal Common Policy CA G20201014133512Z401014133512Z0\10	UUS10U
+U.S. Government10UFPKI1$0"UFederal Common Policy CA G20Ç"0	*ÜHÜ˜ Ç 0Ç
+Ç ◊◊”1&!*AmÀØΩˆƒQå$ÿà{.Z§&l‚∏)Oø‰˛eáyøMF`Œ+,'!a„7ﬂÙ8» ®9=ndÈh6ØÍÜÙØ›î¢üÔπ˘&!æ€NAﬁ\qjP0Õ©H`÷ªZ)¨^m ¶XZî‘˙syÄ›Ä“∑èªÊ-tÊÅ7%ªå69—å`I"hn’ìJxK‰NGÃÌTèTæÄ=P!∆o(Oå1H‚#gÛ2¡wÂ|√í÷n‘Ûl&I&õ≈Ä9í·Œ+‹:º≠†¯è~Ã©èœÔ3∏¢íÎáaÁ 8]Å£ 6uP¸éiæ.NÛÅZáˇ8?h.ƒ€V•ê-C”lj0‡I≠FØ6$∫ôB\´1ªÀæÖy¡$…Û¿iDÉÅüRQÚì¥ﬁFZô›ó¡¬Pˆ—⁄.·•_B˘N<5]±?=±NÀÌ#¨1æﬂ˘8⁄0{(}“B«ª€*:3#E„´ÆòÓÔ9ÂÑ‰’ël±¢–Tﬂn◊e˙∑€©P2˙˘Po©@ “≤‘IÎH>ù‘ñ÷$b\™S.]$°vcr‡ S]bfá≠∫‚wGe(ã=B*¬9æ¬∞Àkì·∏Àe„·sz≠ÚÊ„Öìv5¨˛·É˘˙w“<•.,å˝Dˆz^ﬁcâz9™ó0Ñ_'H £Åñ0Åì0Uˇ0ˇ0Uˇ0UÙ'\©√|GÙ˙¶ß∞Yó™›5&„0Q+E0C0A+0Ü5http://repo.fpki.gov/fcpca/caCertsIssuedByfcpcag2.p7c0	*ÜHÜ˜ Ç d70ŒΩŒ’Åí:4(˚xÇ˚¸é_¡0KÜöÑM°™R'¥Ç§h‹£∂2Åµß#ÀûbÑÜ<Ó°Çêq∞5~ﬁ‡)rÂ	c‚õB…mê¨‡°›≥ò¸Ç—±`=ã;^5'ÉY‘:t5√œßkÊÁ¥ÁÃŒhÓ˙ÀäSœ≤±7qG¬ã†œ{™{ô>9≤X§-\sLÀSß˙£…Ry≈?A@I‹Íÿ'-‚µ0¥
+∑;ﬂ¿zì!ÛR≤%n∏˝°é¯MË›
+˘8B<˘Ó‘≠äd±∏ß#*t∏À∫’ÙbêπÖÑãˇo¶ˆø2âÇÙ˙bCr¥’≥Cÿ|ÌC)H'”ù‡j9O¬∑;ò‹/ƒ≥™VÜ>a™¶q"ı•Ä`rWO6„Ãe skº¯¨<^˛	}¯UXåU(~Kì¬∂∆'‡Æc‚”˚î◊≠…D±+2k±HTSQ√Z€ú!c»ë+[''…L◊ã]P4tY Í@al‚‹ôÃ°>a¶ùˇ,¡i°@„†∞èëOÚµˆh¶YúŒCÅ#Ç<§Î{Ã®‹≈”»ÖN≈v{Êëxª»ΩNô†PB]ÔXı®√»ëo-E»Q∑ê}/y˜µ»ú±’<ë]åyÔÒ'˜4pÅŸXÃ4ÑY=∫-----BEGIN CERTIFICATE-----
+MIIGYzCCBEugAwIBAgIJAIOrle8n4k6dMA0GCSqGSIb3DQEBDQUAMHExCzAJBgNV
+BAYTAlVTMREwDwYDVQQIEwhWaXJnaW5pYTEVMBMGA1UEBxMMTmV3cG9ydCBOZXdz
+MRYwFAYDVQQKEw1KZWZmZXJzb24gTGFiMQ8wDQYDVQQLEwZJVC1DTkkxDzANBgNV
+BAMTBkpMYWJDQTAeFw0xNjA4MTYwOTA4NTRaFw0zNjA4MTEwOTA4NTRaMHExCzAJ
+BgNVBAYTAlVTMREwDwYDVQQIEwhWaXJnaW5pYTEVMBMGA1UEBxMMTmV3cG9ydCBO
+ZXdzMRYwFAYDVQQKEw1KZWZmZXJzb24gTGFiMQ8wDQYDVQQLEwZJVC1DTkkxDzAN
+BgNVBAMTBkpMYWJDQTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK0c
+Nqo89Rw/1J4dwBJPTbh1IaPBVk4EzI5XbngLb4xg5IZWVL4aDnSq551Ml9mc1Cyk
+Kxen6Ghsd0a7o0kkKsO1MJUvzGGeXAYR0rp/thmooTtK539qd2cKU2IrC+YbVzHK
+gIE4T2Zykfm+N9TUS871NDwcjH8HmJgJvMs1uG6Hke9onaTj7wvx+cIibP5hdAKW
+Cz6M2wHJKVol0IybUtEOAqtgrmvE6C1IHWAAefYaM3ptzPIJc784V+r00HFG/qYj
+jN6vVvhwffHaAxY/W2w+A4wCcgLfEMLtc7lntKxlvPck/MpgPcSSEPJWnVbex9Yg
+rinTfn2wvDpreCM/a3bqKGv4J41mg2UPsCUFljH1yE/6WIlyuYZEqSveVWmRbBR2
+uJ2R2PJvFHP9CwjqhhcR4Sr758pHQfAzSVHqxmmktHyShFE698vJVBkt4y0VfEck
+a5tKaQSHYW1nO3fUMLYwdmLpIcgufNO1jSheGKCaZiwxSy4aezUVoxu+q6RyaJMA
+K5PgbKszW8ZiSGFTsEwGH+cCO3ixDqYWumbxSxjIU8sWe/zmozZesE5kIUYpVwVw
+S0kl9oOI0ZDYE8JGIG9HHJHakXk1VaW92AaK7COazae3weDz1d6KXgdG/xAP947H
++Fk9iByg1WHGcn59ywFNzOia2SVCQbVEGqgS61efAgMBAAGjgf0wgfowDwYDVR0T
+AQH/BAUwAwEB/zAdBgNVHQ4EFgQUcLwLMUclwhiGTgDkL0fGve66X+0wgaMGA1Ud
+IwSBmzCBmIAUcLwLMUclwhiGTgDkL0fGve66X+2hdaRzMHExCzAJBgNVBAYTAlVT
+MREwDwYDVQQIEwhWaXJnaW5pYTEVMBMGA1UEBxMMTmV3cG9ydCBOZXdzMRYwFAYD
+VQQKEw1KZWZmZXJzb24gTGFiMQ8wDQYDVQQLEwZJVC1DTkkxDzANBgNVBAMTBkpM
+YWJDQYIJAIOrle8n4k6dMA4GA1UdDwEB/wQEAwIBBjASBgkrBgEEAYI3FQEEBQID
+AwADMA0GCSqGSIb3DQEBDQUAA4ICAQCCwWOQz+zkZBBGtYkwkrDLZGfa1IEHIzub
+yJSgmMs/9ZEJzsjzhw8bI7jJ7hiGdultRvKRxXFvtLFeleuXrriOqw+8BsTJUdgn
+H/GY2qg/V2CyC1WZ2mRJPPKBAktvBgRHDUgyi7xYNOzaiKFdCmovjCTCh3eD2WiS
+3XaW4z7Zk3FFmUs/VkhhuV0+D9nR0J9hQGPD9+KZ4PSiPd/ZaeM5DshcVwUUTBal
+spnoCwkwR8hXFhwXkrkTXRiaBWDXTl15bkA+ZF1KH4xqQ/Ur0EsYp6MJ++c+sOn1
+6vpVtL4fNkze0vVi3YwXifYwUa5TIgJRo5emdGoTgI2VGt9YTaJIMSN49RDsXsiy
++65nlqYzpT9kDCdLkLGZ0rabqpcTRLPypj7S8E0QwFXIhdSZtaksDl1TefVQIECX
+JbgkdWhqtuK3LvwQehT0jkdd2bc0OwSCQxBP/m3rRy1kHvLFgiK4jMMhG9c/75GT
+E7AZ7OEYxwN1PBtNKuzapH0hvjYoyBBKsCUey9asXoq6bhCbyKfTl0/42wEW25on
+iBsGpGbp8JS1wfYZwO/l2zPcU72P6Gy62CaLkULeYchMQ80tOw04uUZ8WLHSA309
++iFiI8RodkvlR7lwgD2y+fbdQb24lO8YdnXJgtHGn9PkOM3ONo5MaxC5XhuFJXvI
+oOKOQVSAQg==
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1 (0x1)
+    Signature Algorithm: sha512WithRSAEncryption
+        Issuer: C=US, ST=Virginia, L=Newport News, O=Jefferson Lab, OU=IT-CNI, CN=JLabCA
+        Validity
+            Not Before: Aug 16 09:12:44 2016 GMT
+            Not After : Aug 11 09:12:44 2036 GMT
+        Subject: C=US, ST=Virginia, L=Newport News, O=Jefferson Lab, OU=IT-CNI, CN=JLABICA10-JLabACA, DC=jlab, DC=org
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (4096 bit)
+                Modulus:
+                    00:89:08:d4:0d:67:ad:78:ec:9d:a8:ff:0d:07:01:
+                    ee:de:a3:35:9b:21:ff:5b:c8:ac:78:2d:2f:de:97:
+                    29:5c:7b:46:f5:90:09:93:78:ed:28:0a:5b:39:08:
+                    a9:c8:24:f5:1f:db:49:9b:8e:7d:e0:84:76:c5:3b:
+                    40:59:d1:5e:5d:3a:82:34:37:e5:2a:55:b3:3b:fb:
+                    f7:bd:36:b0:de:a9:15:ae:57:44:f2:32:2d:96:b6:
+                    66:83:9d:8c:1d:12:b4:74:3f:53:da:03:0c:35:5a:
+                    b9:2b:ee:90:52:4a:bc:08:8c:ec:4e:03:77:64:f7:
+                    1c:a1:cd:fd:c3:a2:d6:ff:28:15:0c:49:94:96:e8:
+                    88:56:39:fe:06:65:55:94:ba:b0:dc:3e:ea:30:44:
+                    65:34:d8:3c:28:f2:c9:0a:48:06:4f:bf:fe:12:53:
+                    de:36:61:31:72:db:59:f6:05:5d:e7:42:17:65:81:
+                    ec:cf:ed:d4:46:01:75:68:8a:bd:cb:43:00:ec:9b:
+                    2f:65:fc:76:c9:ac:57:14:c2:a4:3d:21:93:93:06:
+                    5a:f6:f9:9f:cc:37:f5:c1:ae:42:1b:a4:70:04:6b:
+                    c6:4d:9c:47:79:f4:ee:35:9a:b2:3c:5c:ea:33:1c:
+                    c8:2c:9b:d9:42:d8:0f:11:83:0a:3f:89:47:0e:9e:
+                    51:f0:4d:f5:0d:5a:d4:9e:3b:2a:0f:56:f9:c1:b4:
+                    77:de:1c:fb:46:50:02:f8:ec:7a:f4:16:65:25:03:
+                    8a:71:85:48:95:c6:eb:75:a4:72:6e:07:6a:8e:36:
+                    da:f2:e6:dd:c7:74:24:cd:12:1d:d5:98:a6:dc:e3:
+                    a0:71:bc:4a:a6:ab:c0:a8:a9:97:82:a5:98:dd:96:
+                    80:bd:d0:04:ad:a4:0f:29:24:dc:c5:91:3a:49:a1:
+                    3b:8c:f5:66:7d:a3:56:98:bc:57:5f:63:91:07:17:
+                    ca:8f:2d:6a:65:69:db:1e:83:5f:1e:73:f8:ef:b8:
+                    88:8d:ff:64:ac:20:03:36:8c:3f:f5:ae:80:e6:2d:
+                    0a:5b:af:2a:53:dc:33:94:c4:34:d8:5d:d4:d6:36:
+                    92:ee:75:b8:f0:11:27:06:38:44:e3:ab:75:3e:7d:
+                    97:f9:df:37:94:ac:a6:57:3c:e8:ba:31:ab:c6:5b:
+                    b6:01:02:7b:28:f1:23:a0:a0:ac:ab:05:05:db:45:
+                    93:ed:bd:3d:e1:be:11:8b:30:d9:90:c1:9e:1b:9b:
+                    1e:9c:ba:f6:3b:56:89:79:7c:14:fe:df:38:37:3b:
+                    b2:60:a2:ee:1d:09:5b:f4:3d:e3:fe:8f:8c:0d:c1:
+                    4f:ae:9c:c5:e8:d9:66:28:cb:6b:6a:49:d9:63:ff:
+                    e5:27:1d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:9
+            X509v3 Subject Key Identifier: 
+                F7:35:5B:AE:88:07:B8:40:D1:60:5F:28:2F:3E:B3:29:BB:0F:A1:34
+            X509v3 Authority Key Identifier: 
+                keyid:70:BC:0B:31:47:25:C2:18:86:4E:00:E4:2F:47:C6:BD:EE:BA:5F:ED
+                DirName:/C=US/ST=Virginia/L=Newport News/O=Jefferson Lab/OU=IT-CNI/CN=JLabCA
+                serial:83:AB:95:EF:27:E2:4E:9D
+
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://pki.jlab.org/2016/JLabCA.crl
+
+            Authority Information Access: 
+                CA Issuers - URI:http://pki.jlab.org/2016/AIA/JLabCA.crt
+                OCSP - URI:http://ocsp.jlab.org/ocsp
+
+    Signature Algorithm: sha512WithRSAEncryption
+         4d:0b:8c:70:28:5c:ed:4f:6e:3e:0d:cb:2b:13:a2:18:8e:c1:
+         be:66:2c:57:0a:8f:74:ec:38:16:b4:b6:98:1f:e6:a3:9a:91:
+         85:1d:ed:0e:39:cb:eb:7e:5e:c8:70:a2:75:11:0f:10:10:56:
+         91:90:cf:f8:be:30:3d:c0:7d:34:d3:0e:06:8d:dd:9f:b8:9b:
+         f7:c1:1f:26:54:1c:57:5d:fe:36:73:7c:d0:c4:a1:d1:23:b6:
+         a5:b3:75:f3:64:ae:33:39:6f:70:22:f2:46:eb:ae:f9:a8:53:
+         38:83:f7:48:dc:11:69:c3:87:d7:c0:61:7d:37:23:47:08:8a:
+         a5:de:09:f5:d4:da:84:6b:f5:a5:08:c7:e0:a2:07:10:8c:c8:
+         43:10:11:46:d1:51:79:eb:d9:bb:b3:83:92:dd:ea:b4:1d:cf:
+         c4:fb:08:14:45:64:26:ac:0f:c2:26:3f:ba:35:2c:02:e1:71:
+         1d:df:59:81:23:2e:d8:eb:25:5a:0a:17:45:6d:50:58:d5:9b:
+         7b:a3:e0:47:27:65:b3:d4:29:5b:69:8c:1f:a5:28:6f:e3:c4:
+         60:79:e9:0f:88:24:76:5b:39:39:45:5b:83:2a:d4:a1:55:9d:
+         01:11:b5:14:eb:46:e6:f2:8b:b5:27:51:e4:3b:c4:c8:f2:93:
+         35:24:d2:45:09:f0:47:1f:8c:5d:2d:d3:2a:a7:e0:be:e0:20:
+         c0:a5:6a:55:2f:c1:b1:ef:5c:c7:3e:30:94:45:5e:c0:ab:3d:
+         64:23:e8:5f:79:b2:b9:ad:b6:f6:e0:c0:b3:ff:e1:80:92:e7:
+         9b:cb:3d:35:ec:db:82:ff:7b:e7:8e:ee:bd:d5:de:5b:4e:6b:
+         fd:12:d1:c7:66:2e:d8:9c:89:89:a7:a2:8f:ae:6a:46:aa:e5:
+         c9:0e:78:eb:ed:f8:09:73:66:39:92:57:03:e3:69:72:13:94:
+         4c:e1:d5:cd:bc:82:19:e8:62:b9:32:ce:5e:e6:d4:de:91:de:
+         e0:f0:43:5e:5b:ff:39:13:8a:37:50:d7:f9:9b:a9:33:fc:08:
+         81:ec:ce:da:1d:cd:a8:a9:a3:49:da:77:6d:6f:98:34:db:02:
+         15:31:b4:0d:76:e1:a5:59:bf:be:9c:3b:31:6d:01:d7:92:d3:
+         a5:99:5d:9b:b1:42:03:81:74:db:05:fc:3e:78:db:f6:7d:4a:
+         18:94:bd:08:bb:fa:74:dc:19:ca:5d:b0:ec:5e:9d:26:51:1a:
+         43:a2:1e:28:fc:08:19:39:a1:0a:60:5f:c2:98:78:95:9c:6b:
+         94:a0:9e:b9:22:02:97:70:f4:b8:16:2b:d5:96:1b:9e:25:64:
+         7c:5e:6c:8a:fb:78:34:3a
+-----BEGIN CERTIFICATE-----
+MIIHJTCCBQ2gAwIBAgIBATANBgkqhkiG9w0BAQ0FADBxMQswCQYDVQQGEwJVUzER
+MA8GA1UECBMIVmlyZ2luaWExFTATBgNVBAcTDE5ld3BvcnQgTmV3czEWMBQGA1UE
+ChMNSmVmZmVyc29uIExhYjEPMA0GA1UECxMGSVQtQ05JMQ8wDQYDVQQDEwZKTGFi
+Q0EwHhcNMTYwODE2MDkxMjQ0WhcNMzYwODExMDkxMjQ0WjCBpzELMAkGA1UEBhMC
+VVMxETAPBgNVBAgTCFZpcmdpbmlhMRUwEwYDVQQHEwxOZXdwb3J0IE5ld3MxFjAU
+BgNVBAoTDUplZmZlcnNvbiBMYWIxDzANBgNVBAsTBklULUNOSTEaMBgGA1UEAxMR
+SkxBQklDQTEwLUpMYWJBQ0ExFDASBgoJkiaJk/IsZAEZFgRqbGFiMRMwEQYKCZIm
+iZPyLGQBGRYDb3JnMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAiQjU
+DWeteOydqP8NBwHu3qM1myH/W8iseC0v3pcpXHtG9ZAJk3jtKApbOQipyCT1H9tJ
+m4594IR2xTtAWdFeXTqCNDflKlWzO/v3vTaw3qkVrldE8jItlrZmg52MHRK0dD9T
+2gMMNVq5K+6QUkq8CIzsTgN3ZPccoc39w6LW/ygVDEmUluiIVjn+BmVVlLqw3D7q
+MERlNNg8KPLJCkgGT7/+ElPeNmExcttZ9gVd50IXZYHsz+3URgF1aIq9y0MA7Jsv
+Zfx2yaxXFMKkPSGTkwZa9vmfzDf1wa5CG6RwBGvGTZxHefTuNZqyPFzqMxzILJvZ
+QtgPEYMKP4lHDp5R8E31DVrUnjsqD1b5wbR33hz7RlAC+Ox69BZlJQOKcYVIlcbr
+daRybgdqjjba8ubdx3QkzRId1Zim3OOgcbxKpqvAqKmXgqWY3ZaAvdAEraQPKSTc
+xZE6SaE7jPVmfaNWmLxXX2ORBxfKjy1qZWnbHoNfHnP477iIjf9krCADNow/9a6A
+5i0KW68qU9wzlMQ02F3U1jaS7nW48BEnBjhE46t1Pn2X+d83lKymVzzoujGrxlu2
+AQJ7KPEjoKCsqwUF20WT7b094b4RizDZkMGeG5senLr2O1aJeXwU/t84NzuyYKLu
+HQlb9D3j/o+MDcFPrpzF6NlmKMtraknZY//lJx0CAwEAAaOCAY8wggGLMBIGA1Ud
+EwEB/wQIMAYBAf8CAQkwHQYDVR0OBBYEFPc1W66IB7hA0WBfKC8+sym7D6E0MIGj
+BgNVHSMEgZswgZiAFHC8CzFHJcIYhk4A5C9Hxr3uul/toXWkczBxMQswCQYDVQQG
+EwJVUzERMA8GA1UECBMIVmlyZ2luaWExFTATBgNVBAcTDE5ld3BvcnQgTmV3czEW
+MBQGA1UEChMNSmVmZmVyc29uIExhYjEPMA0GA1UECxMGSVQtQ05JMQ8wDQYDVQQD
+EwZKTGFiQ0GCCQCDq5XvJ+JOnTAOBgNVHQ8BAf8EBAMCAQYwNAYDVR0fBC0wKzAp
+oCegJYYjaHR0cDovL3BraS5qbGFiLm9yZy8yMDE2L0pMYWJDQS5jcmwwagYIKwYB
+BQUHAQEEXjBcMDMGCCsGAQUFBzAChidodHRwOi8vcGtpLmpsYWIub3JnLzIwMTYv
+QUlBL0pMYWJDQS5jcnQwJQYIKwYBBQUHMAGGGWh0dHA6Ly9vY3NwLmpsYWIub3Jn
+L29jc3AwDQYJKoZIhvcNAQENBQADggIBAE0LjHAoXO1Pbj4NyysTohiOwb5mLFcK
+j3TsOBa0tpgf5qOakYUd7Q45y+t+XshwonURDxAQVpGQz/i+MD3AfTTTDgaN3Z+4
+m/fBHyZUHFdd/jZzfNDEodEjtqWzdfNkrjM5b3Ai8kbrrvmoUziD90jcEWnDh9fA
+YX03I0cIiqXeCfXU2oRr9aUIx+CiBxCMyEMQEUbRUXnr2buzg5Ld6rQdz8T7CBRF
+ZCasD8ImP7o1LALhcR3fWYEjLtjrJVoKF0VtUFjVm3uj4EcnZbPUKVtpjB+lKG/j
+xGB56Q+IJHZbOTlFW4Mq1KFVnQERtRTrRubyi7UnUeQ7xMjykzUk0kUJ8EcfjF0t
+0yqn4L7gIMClalUvwbHvXMc+MJRFXsCrPWQj6F95srmttvbgwLP/4YCS55vLPTXs
+24L/e+eO7r3V3ltOa/0S0cdmLticiYmnoo+uakaq5ckOeOvt+AlzZjmSVwPjaXIT
+lEzh1c28ghnoYrkyzl7m1N6R3uDwQ15b/zkTijdQ1/mbqTP8CIHsztodzaipo0na
+d21vmDTbAhUxtA124aVZv76cOzFtAdeS06WZXZuxQgOBdNsF/D542/Z9ShiUvQi7
++nTcGcpdsOxenSZRGkOiHij8CBk5oQpgX8KYeJWca5SgnrkiApdw9LgWK9WWG54l
+ZHxebIr7eDQ6
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 2 (0x2)
+    Signature Algorithm: sha512WithRSAEncryption
+        Issuer: C=US, ST=Virginia, L=Newport News, O=Jefferson Lab, OU=IT-CNI, CN=JLabCA
+        Validity
+            Not Before: Aug 16 09:13:47 2016 GMT
+            Not After : Aug 11 09:13:47 2036 GMT
+        Subject: C=US, ST=Virginia, L=Newport News, O=Jefferson Lab, OU=IT-CNI, CN=JLABICA6-JLabPubCA, DC=jlab, DC=org
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (4096 bit)
+                Modulus:
+                    00:ba:cd:63:6a:53:46:de:2f:9d:cf:55:84:61:34:
+                    bb:d9:60:95:eb:6c:4e:1f:1a:27:f4:36:dd:e0:4f:
+                    fc:b0:66:a6:61:79:90:ba:09:39:95:91:95:ac:62:
+                    7a:73:81:9c:19:c7:a4:68:7f:6c:63:d8:51:d2:bf:
+                    38:80:01:37:cf:f2:55:ef:67:72:d1:d1:4a:52:02:
+                    d9:76:42:08:e5:62:c8:bb:17:ef:c2:6b:a7:0e:22:
+                    03:e2:98:4a:f7:92:5f:81:dc:4d:00:99:22:fe:82:
+                    c3:a8:e7:c7:35:cf:57:eb:7c:21:60:d7:c1:57:0c:
+                    da:2d:8d:e4:c4:7e:e1:df:1d:05:98:a5:7b:10:3c:
+                    50:2a:34:12:4d:dd:9d:1f:a8:90:9f:97:ef:42:c9:
+                    0c:7e:34:3a:77:f1:92:c4:30:53:3f:31:52:06:41:
+                    08:c7:73:19:a7:39:78:83:35:30:7c:6f:ab:b2:11:
+                    79:81:31:12:d4:50:c6:c4:dc:4b:86:20:9b:b8:b5:
+                    57:3e:16:4c:d6:5d:b5:a8:8a:85:bb:53:7f:6a:57:
+                    84:22:ee:a7:f3:a0:bd:50:cf:87:d6:60:50:49:00:
+                    5e:59:e8:b5:07:47:4b:fd:fe:13:b5:4e:f0:61:43:
+                    fc:00:12:29:49:23:a8:b0:87:2e:cc:ef:7c:4c:13:
+                    e3:39:76:ae:a0:a5:55:77:3d:43:cb:04:87:a1:10:
+                    f1:5d:27:80:ad:e0:37:36:00:6d:45:a9:bd:0c:8e:
+                    ba:4b:f6:bd:46:05:9d:5b:5c:51:48:c6:a4:27:ab:
+                    88:ef:23:f3:6d:2f:20:9c:bb:2e:a6:80:f3:f4:08:
+                    34:10:6c:06:03:fc:bf:03:7d:9a:20:c2:6f:c0:69:
+                    d3:23:1c:7d:d0:2a:cc:a6:1b:15:b3:68:af:5e:1e:
+                    31:f1:92:66:4d:5b:1d:eb:14:b7:2e:ce:8f:42:0f:
+                    67:53:e3:8c:d4:2d:1c:30:2e:a3:4d:ca:bd:65:ba:
+                    2b:15:ed:e2:dd:d8:88:e0:2f:c0:16:de:2b:77:51:
+                    55:64:3e:40:55:d8:9f:d2:38:0c:4b:89:fd:3b:dd:
+                    cc:3d:17:54:64:33:db:3f:20:24:b0:6c:5e:fe:02:
+                    80:d6:61:95:a0:5c:80:b8:6e:46:0b:c4:34:5b:79:
+                    f9:f1:85:88:3f:63:3c:4a:9a:da:67:d3:00:80:f1:
+                    7b:8d:0d:7e:17:b4:ec:89:be:3b:74:3c:f6:95:ff:
+                    be:00:2d:20:83:82:2b:3b:48:1d:c9:0e:fa:4b:6d:
+                    aa:8f:e3:2d:48:a6:37:9c:45:8d:12:ed:c4:b5:cf:
+                    04:cc:46:57:16:f3:ea:6f:f5:0a:b1:5f:d0:7e:48:
+                    5e:2a:2b
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:9
+            X509v3 Subject Key Identifier: 
+                64:B0:67:5F:B8:21:E3:54:19:F5:68:5D:32:70:1F:66:2B:1B:0E:09
+            X509v3 Authority Key Identifier: 
+                keyid:70:BC:0B:31:47:25:C2:18:86:4E:00:E4:2F:47:C6:BD:EE:BA:5F:ED
+                DirName:/C=US/ST=Virginia/L=Newport News/O=Jefferson Lab/OU=IT-CNI/CN=JLabCA
+                serial:83:AB:95:EF:27:E2:4E:9D
+
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://pki.jlab.org/2016/JLabCA.crl
+
+            Authority Information Access: 
+                CA Issuers - URI:http://pki.jlab.org/2016/AIA/JLabCA.crt
+                OCSP - URI:http://ocsp.jlab.org/ocsp
+
+    Signature Algorithm: sha512WithRSAEncryption
+         0b:91:d3:a7:5d:e0:4c:1c:dc:82:49:7f:17:ca:ab:8f:ab:2f:
+         c6:d4:ae:90:a3:02:92:e6:2b:f6:12:e2:a7:8d:c3:0a:07:54:
+         e5:e7:6d:be:5a:cb:19:7b:1b:74:97:f9:06:21:18:62:06:b4:
+         ec:f2:b5:f6:35:85:a1:1d:a7:a6:80:42:d0:f5:77:37:03:c9:
+         2d:eb:9b:c5:8c:5f:da:e2:03:05:67:08:de:4f:e2:1c:c6:21:
+         68:45:02:6e:69:65:44:96:68:29:31:e2:89:f7:c5:cf:88:2c:
+         37:7f:11:9c:82:4d:29:94:7c:d8:1f:0c:85:8d:85:8f:15:79:
+         4a:b9:29:0e:06:62:4c:02:89:c5:0f:dd:bf:c3:95:ae:5a:80:
+         df:41:d0:f9:c7:f7:67:69:d0:a0:e6:f3:48:56:bf:76:ce:ce:
+         40:32:71:8a:28:e0:f6:bb:9b:7e:29:c8:a6:75:f9:5c:e5:71:
+         e4:55:5d:62:1d:eb:09:21:6b:85:bc:b2:8d:a5:fa:9d:05:85:
+         8c:4b:50:b2:38:68:f9:df:52:0c:14:dd:6a:da:a3:22:9a:4f:
+         40:61:6e:2c:ac:71:6c:38:dc:9d:e1:35:2f:0f:72:10:f8:7b:
+         d8:62:0d:d1:f4:6c:b2:97:c9:ef:75:4f:5c:55:2e:3a:30:2b:
+         cb:46:d7:c9:51:02:ee:bb:5c:59:01:58:72:0a:b3:51:58:31:
+         1c:27:29:44:e5:ef:4f:4f:d3:77:6c:99:3d:3a:66:91:c1:55:
+         4c:67:12:c1:dd:e0:a2:46:51:8e:5a:0c:f9:36:ca:cd:78:f3:
+         02:09:ce:6a:de:53:04:dc:00:63:2c:af:1a:83:bf:cc:d8:d8:
+         53:8b:e7:58:8d:c6:c3:e6:aa:2a:9d:f6:02:f0:f0:19:42:a3:
+         db:ca:52:de:0e:38:ea:ce:54:a8:6b:46:58:f5:f5:06:d0:99:
+         3f:1b:aa:b3:df:9b:55:cc:a5:f4:1e:c1:d8:ba:b9:36:b8:73:
+         ef:85:d6:0b:4a:a9:c6:6c:56:a3:37:31:9c:d3:7e:69:ee:94:
+         b8:a7:0a:e5:cf:48:65:1c:a0:f7:16:1f:71:ba:e2:fd:13:ad:
+         85:c4:96:c0:0f:86:48:2b:8a:ed:34:54:fd:3b:06:52:70:5b:
+         8c:5f:6a:30:03:95:3e:d5:8c:44:0a:7e:7f:cf:8f:22:ec:04:
+         ab:a2:8f:5c:5c:d8:cf:36:0e:55:88:b7:9d:dd:38:c5:60:05:
+         64:85:05:98:1e:a5:a9:02:3d:6e:40:8c:9d:2b:1d:8c:e3:c4:
+         c5:03:82:ad:af:32:e7:b2:1f:3d:28:3e:22:3f:cc:fa:45:6c:
+         48:28:7f:cb:4b:7b:60:b2
+-----BEGIN CERTIFICATE-----
+MIIHJjCCBQ6gAwIBAgIBAjANBgkqhkiG9w0BAQ0FADBxMQswCQYDVQQGEwJVUzER
+MA8GA1UECBMIVmlyZ2luaWExFTATBgNVBAcTDE5ld3BvcnQgTmV3czEWMBQGA1UE
+ChMNSmVmZmVyc29uIExhYjEPMA0GA1UECxMGSVQtQ05JMQ8wDQYDVQQDEwZKTGFi
+Q0EwHhcNMTYwODE2MDkxMzQ3WhcNMzYwODExMDkxMzQ3WjCBqDELMAkGA1UEBhMC
+VVMxETAPBgNVBAgTCFZpcmdpbmlhMRUwEwYDVQQHEwxOZXdwb3J0IE5ld3MxFjAU
+BgNVBAoTDUplZmZlcnNvbiBMYWIxDzANBgNVBAsTBklULUNOSTEbMBkGA1UEAxMS
+SkxBQklDQTYtSkxhYlB1YkNBMRQwEgYKCZImiZPyLGQBGRYEamxhYjETMBEGCgmS
+JomT8ixkARkWA29yZzCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALrN
+Y2pTRt4vnc9VhGE0u9lgletsTh8aJ/Q23eBP/LBmpmF5kLoJOZWRlaxienOBnBnH
+pGh/bGPYUdK/OIABN8/yVe9nctHRSlIC2XZCCOViyLsX78Jrpw4iA+KYSveSX4Hc
+TQCZIv6Cw6jnxzXPV+t8IWDXwVcM2i2N5MR+4d8dBZilexA8UCo0Ek3dnR+okJ+X
+70LJDH40OnfxksQwUz8xUgZBCMdzGac5eIM1MHxvq7IReYExEtRQxsTcS4Ygm7i1
+Vz4WTNZdtaiKhbtTf2pXhCLup/OgvVDPh9ZgUEkAXlnotQdHS/3+E7VO8GFD/AAS
+KUkjqLCHLszvfEwT4zl2rqClVXc9Q8sEh6EQ8V0ngK3gNzYAbUWpvQyOukv2vUYF
+nVtcUUjGpCeriO8j820vIJy7LqaA8/QINBBsBgP8vwN9miDCb8Bp0yMcfdAqzKYb
+FbNor14eMfGSZk1bHesUty7Oj0IPZ1PjjNQtHDAuo03KvWW6KxXt4t3YiOAvwBbe
+K3dRVWQ+QFXYn9I4DEuJ/TvdzD0XVGQz2z8gJLBsXv4CgNZhlaBcgLhuRgvENFt5
++fGFiD9jPEqa2mfTAIDxe40Nfhe07Im+O3Q89pX/vgAtIIOCKztIHckO+kttqo/j
+LUimN5xFjRLtxLXPBMxGVxbz6m/1CrFf0H5IXiorAgMBAAGjggGPMIIBizASBgNV
+HRMBAf8ECDAGAQH/AgEJMB0GA1UdDgQWBBRksGdfuCHjVBn1aF0ycB9mKxsOCTCB
+owYDVR0jBIGbMIGYgBRwvAsxRyXCGIZOAOQvR8a97rpf7aF1pHMwcTELMAkGA1UE
+BhMCVVMxETAPBgNVBAgTCFZpcmdpbmlhMRUwEwYDVQQHEwxOZXdwb3J0IE5ld3Mx
+FjAUBgNVBAoTDUplZmZlcnNvbiBMYWIxDzANBgNVBAsTBklULUNOSTEPMA0GA1UE
+AxMGSkxhYkNBggkAg6uV7yfiTp0wDgYDVR0PAQH/BAQDAgEGMDQGA1UdHwQtMCsw
+KaAnoCWGI2h0dHA6Ly9wa2kuamxhYi5vcmcvMjAxNi9KTGFiQ0EuY3JsMGoGCCsG
+AQUFBwEBBF4wXDAzBggrBgEFBQcwAoYnaHR0cDovL3BraS5qbGFiLm9yZy8yMDE2
+L0FJQS9KTGFiQ0EuY3J0MCUGCCsGAQUFBzABhhlodHRwOi8vb2NzcC5qbGFiLm9y
+Zy9vY3NwMA0GCSqGSIb3DQEBDQUAA4ICAQALkdOnXeBMHNyCSX8XyquPqy/G1K6Q
+owKS5iv2EuKnjcMKB1Tl522+WssZext0l/kGIRhiBrTs8rX2NYWhHaemgELQ9Xc3
+A8kt65vFjF/a4gMFZwjeT+IcxiFoRQJuaWVElmgpMeKJ98XPiCw3fxGcgk0plHzY
+HwyFjYWPFXlKuSkOBmJMAonFD92/w5WuWoDfQdD5x/dnadCg5vNIVr92zs5AMnGK
+KOD2u5t+Kcimdflc5XHkVV1iHesJIWuFvLKNpfqdBYWMS1CyOGj531IMFN1q2qMi
+mk9AYW4srHFsONyd4TUvD3IQ+HvYYg3R9Gyyl8nvdU9cVS46MCvLRtfJUQLuu1xZ
+AVhyCrNRWDEcJylE5e9PT9N3bJk9OmaRwVVMZxLB3eCiRlGOWgz5NsrNePMCCc5q
+3lME3ABjLK8ag7/M2NhTi+dYjcbD5qoqnfYC8PAZQqPbylLeDjjqzlSoa0ZY9fUG
+0Jk/G6qz35tVzKX0HsHYurk2uHPvhdYLSqnGbFajNzGc035p7pS4pwrlz0hlHKD3
+Fh9xuuL9E62FxJbAD4ZIK4rtNFT9OwZScFuMX2owA5U+1YxECn5/z48i7ASroo9c
+XNjPNg5ViLed3TjFYAVkhQWYHqWpAj1uQIydKx2M48TFA4KtrzLnsh89KD4iP8z6
+RWxIKH/LS3tgsg==
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+    Signature Algorithm: sha512WithRSAEncryption
+        Issuer: C=US, ST=Virginia, L=Newport News, O=Jefferson Lab, OU=IT-CNI, CN=JLabCA
+        Validity
+            Not Before: Aug 16 09:14:29 2016 GMT
+            Not After : Aug 11 09:14:29 2036 GMT
+        Subject: C=US, ST=Virginia, L=Newport News, O=Jefferson Lab, OU=IT-CNI, CN=JLABICA7-JLabNSCA, DC=jlab, DC=org
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (4096 bit)
+                Modulus:
+                    00:b8:3b:6f:74:fe:68:e8:7f:71:19:a8:32:6c:d8:
+                    d2:cf:d1:1f:33:e5:14:6f:6a:72:3e:f5:a4:c7:7a:
+                    36:cd:fb:d9:4e:d2:01:34:06:0e:6a:c5:fa:e0:a4:
+                    03:4b:88:c6:e9:9d:ec:77:56:13:3d:58:8d:5d:69:
+                    9e:69:27:7c:e7:bc:1c:d1:a8:1e:29:2f:0e:70:5d:
+                    50:2f:b3:ab:2e:c9:05:e6:2f:d6:dd:a3:31:2b:c7:
+                    08:a7:43:ee:64:81:2f:d6:49:29:fc:40:ed:b5:ca:
+                    db:b9:db:f7:38:81:e8:ea:c9:87:ce:51:7c:f9:49:
+                    5d:52:52:1d:95:df:90:be:be:12:fd:b9:21:ee:1a:
+                    b6:d8:ea:bc:89:a0:ce:be:76:be:c3:26:39:ce:2f:
+                    c9:7f:17:68:23:28:c1:cd:86:04:49:c8:16:8c:90:
+                    54:8d:b3:af:2d:30:44:e0:4b:69:c2:27:8f:b5:c3:
+                    d4:19:15:3a:19:40:38:fb:38:b4:e9:26:fe:85:c3:
+                    2f:39:05:18:43:bd:0d:7e:92:77:fe:bb:6d:4f:82:
+                    15:d6:00:f6:ce:ed:53:19:08:20:c4:90:6c:a1:2f:
+                    04:29:9b:69:a5:72:2a:1f:2c:62:d0:bd:62:70:12:
+                    2d:50:c5:cf:b4:d9:20:02:df:5d:3d:ac:19:2c:9e:
+                    f2:a4:dc:bd:15:cc:6a:5b:e8:32:d5:37:13:05:85:
+                    07:e9:23:2f:6f:55:93:6d:35:cf:5a:8c:5d:f6:2d:
+                    9d:58:d4:8e:34:bb:3a:68:80:dd:70:1d:fa:68:49:
+                    e4:23:62:01:03:3c:9b:91:84:20:4a:64:04:8b:96:
+                    b5:7c:a6:18:97:cc:e6:14:3c:32:9d:4f:c1:81:ce:
+                    95:5f:6a:48:53:8b:58:78:9b:85:60:4c:3d:11:3f:
+                    52:02:40:fc:69:c1:8e:72:d2:f2:35:b3:48:b6:79:
+                    1b:99:90:3a:9c:81:fb:d9:d2:99:b3:64:10:7e:66:
+                    db:fa:11:01:e9:56:0e:0b:29:56:55:4e:e3:69:0a:
+                    a2:d4:e9:91:03:b6:71:f1:15:02:3a:d9:1a:67:91:
+                    4c:db:c8:07:8e:3c:4f:cc:48:63:25:ff:03:a8:d0:
+                    80:58:83:2e:2f:71:8e:a3:c1:30:51:cb:da:9e:7f:
+                    76:ee:b8:98:d5:e9:58:86:6c:3a:24:d1:2a:70:e0:
+                    03:8b:e4:4e:ae:34:b9:69:e1:94:f1:d2:16:b6:14:
+                    32:a2:28:c5:1c:65:9a:b0:cb:8f:2d:5e:89:e0:71:
+                    6a:e7:b2:d2:2d:57:ed:12:08:99:9e:00:cb:0e:0c:
+                    88:0b:e1:9f:6f:53:11:9c:d3:62:35:66:7a:88:1d:
+                    1a:e4:9d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:9
+            X509v3 Subject Key Identifier: 
+                65:D3:4C:51:5E:D8:4B:96:49:10:9C:BC:48:18:ED:85:AA:05:00:9C
+            X509v3 Authority Key Identifier: 
+                keyid:70:BC:0B:31:47:25:C2:18:86:4E:00:E4:2F:47:C6:BD:EE:BA:5F:ED
+                DirName:/C=US/ST=Virginia/L=Newport News/O=Jefferson Lab/OU=IT-CNI/CN=JLabCA
+                serial:83:AB:95:EF:27:E2:4E:9D
+
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://pki.jlab.org/2016/JLabCA.crl
+
+            Authority Information Access: 
+                CA Issuers - URI:http://pki.jlab.org/2016/AIA/JLabCA.crt
+                OCSP - URI:http://ocsp.jlab.org/ocsp
+
+    Signature Algorithm: sha512WithRSAEncryption
+         3b:69:3a:85:4e:97:4e:bc:ff:e9:ed:c5:9f:e4:e6:56:73:8c:
+         8b:4d:57:34:d8:11:00:79:63:83:7c:61:ac:6f:24:20:f7:37:
+         a6:b4:96:dc:62:b3:cd:5d:09:0c:52:75:3d:02:7d:b6:40:ca:
+         0c:be:ea:7d:b1:79:37:c9:db:8c:50:d9:8b:23:59:6d:05:82:
+         38:bf:31:4b:a7:5f:3a:dd:0a:37:5f:db:31:a2:3e:84:83:98:
+         10:72:55:34:ff:9d:d3:b8:67:15:b9:b7:09:f7:2a:0c:63:a0:
+         9d:43:15:f5:ee:1b:64:29:61:99:eb:0a:60:a6:ab:b5:47:3d:
+         2a:72:15:95:e1:83:24:20:49:8a:54:d2:97:67:0e:e4:16:8b:
+         b0:f6:45:7b:8b:20:5c:ed:71:35:89:5a:2e:91:da:4e:d4:5d:
+         f8:de:66:9a:3d:26:27:86:0e:a7:04:fa:b2:4b:dd:d8:33:23:
+         c5:52:5d:e4:dc:fb:37:8f:98:35:68:8c:32:25:16:32:09:e6:
+         9c:a3:e6:ec:58:76:b2:37:ab:9a:27:3e:97:11:23:19:71:0a:
+         34:09:23:ea:78:8e:3c:6a:39:19:55:71:3f:35:dd:bd:b7:d4:
+         de:c4:9d:d8:42:64:9a:68:72:5d:05:a4:c7:46:b7:87:ab:c7:
+         e8:c0:cc:9a:39:66:bd:8e:85:2a:8e:31:2d:37:0a:16:41:6e:
+         e8:16:8f:98:9e:c6:6f:eb:c8:57:dc:19:f7:b9:35:bc:aa:07:
+         9f:5f:c2:49:96:19:99:62:4a:86:fa:54:e9:fa:ae:c9:4f:f1:
+         74:83:d8:ec:55:f2:a1:df:dc:93:66:26:03:01:06:9f:f5:34:
+         62:8b:a7:58:43:1f:2e:a3:f0:31:24:d7:ec:ff:5c:c4:5a:7a:
+         5a:9b:39:8a:03:45:b6:2b:e4:d8:b0:65:06:9a:4e:3d:de:38:
+         06:24:16:c4:f3:25:da:02:fe:67:38:3f:cc:9d:12:f5:b3:8f:
+         94:71:52:fe:3a:a9:79:ad:3a:3f:fa:19:be:33:fa:36:60:63:
+         80:2d:97:fb:45:d0:12:30:19:a0:04:a5:b5:15:2e:3f:d0:aa:
+         06:a0:c9:f7:5c:49:a9:7d:f6:ec:9d:7b:d6:b4:57:4e:86:ca:
+         25:d1:c2:5c:54:ed:b5:80:77:d8:6e:73:55:3d:d8:1f:69:5b:
+         17:34:70:de:26:03:42:a1:23:c4:ae:08:09:52:5f:0d:49:9c:
+         cd:d5:de:42:51:85:7e:e3:9a:40:a5:45:58:88:bb:74:66:c5:
+         5e:14:d8:e6:59:54:ea:4b:d6:09:75:22:0f:a3:85:ea:aa:92:
+         94:6b:7c:bf:37:74:f9:9a
+-----BEGIN CERTIFICATE-----
+MIIHJTCCBQ2gAwIBAgIBAzANBgkqhkiG9w0BAQ0FADBxMQswCQYDVQQGEwJVUzER
+MA8GA1UECBMIVmlyZ2luaWExFTATBgNVBAcTDE5ld3BvcnQgTmV3czEWMBQGA1UE
+ChMNSmVmZmVyc29uIExhYjEPMA0GA1UECxMGSVQtQ05JMQ8wDQYDVQQDEwZKTGFi
+Q0EwHhcNMTYwODE2MDkxNDI5WhcNMzYwODExMDkxNDI5WjCBpzELMAkGA1UEBhMC
+VVMxETAPBgNVBAgTCFZpcmdpbmlhMRUwEwYDVQQHEwxOZXdwb3J0IE5ld3MxFjAU
+BgNVBAoTDUplZmZlcnNvbiBMYWIxDzANBgNVBAsTBklULUNOSTEaMBgGA1UEAxMR
+SkxBQklDQTctSkxhYk5TQ0ExFDASBgoJkiaJk/IsZAEZFgRqbGFiMRMwEQYKCZIm
+iZPyLGQBGRYDb3JnMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAuDtv
+dP5o6H9xGagybNjSz9EfM+UUb2pyPvWkx3o2zfvZTtIBNAYOasX64KQDS4jG6Z3s
+d1YTPViNXWmeaSd857wc0ageKS8OcF1QL7OrLskF5i/W3aMxK8cIp0PuZIEv1kkp
+/EDttcrbudv3OIHo6smHzlF8+UldUlIdld+Qvr4S/bkh7hq22Oq8iaDOvna+wyY5
+zi/JfxdoIyjBzYYEScgWjJBUjbOvLTBE4EtpwiePtcPUGRU6GUA4+zi06Sb+hcMv
+OQUYQ70NfpJ3/rttT4IV1gD2zu1TGQggxJBsoS8EKZtppXIqHyxi0L1icBItUMXP
+tNkgAt9dPawZLJ7ypNy9FcxqW+gy1TcTBYUH6SMvb1WTbTXPWoxd9i2dWNSONLs6
+aIDdcB36aEnkI2IBAzybkYQgSmQEi5a1fKYYl8zmFDwynU/Bgc6VX2pIU4tYeJuF
+YEw9ET9SAkD8acGOctLyNbNItnkbmZA6nIH72dKZs2QQfmbb+hEB6VYOCylWVU7j
+aQqi1OmRA7Zx8RUCOtkaZ5FM28gHjjxPzEhjJf8DqNCAWIMuL3GOo8EwUcvann92
+7riY1elYhmw6JNEqcOADi+ROrjS5aeGU8dIWthQyoijFHGWasMuPLV6J4HFq57LS
+LVftEgiZngDLDgyIC+Gfb1MRnNNiNWZ6iB0a5J0CAwEAAaOCAY8wggGLMBIGA1Ud
+EwEB/wQIMAYBAf8CAQkwHQYDVR0OBBYEFGXTTFFe2EuWSRCcvEgY7YWqBQCcMIGj
+BgNVHSMEgZswgZiAFHC8CzFHJcIYhk4A5C9Hxr3uul/toXWkczBxMQswCQYDVQQG
+EwJVUzERMA8GA1UECBMIVmlyZ2luaWExFTATBgNVBAcTDE5ld3BvcnQgTmV3czEW
+MBQGA1UEChMNSmVmZmVyc29uIExhYjEPMA0GA1UECxMGSVQtQ05JMQ8wDQYDVQQD
+EwZKTGFiQ0GCCQCDq5XvJ+JOnTAOBgNVHQ8BAf8EBAMCAQYwNAYDVR0fBC0wKzAp
+oCegJYYjaHR0cDovL3BraS5qbGFiLm9yZy8yMDE2L0pMYWJDQS5jcmwwagYIKwYB
+BQUHAQEEXjBcMDMGCCsGAQUFBzAChidodHRwOi8vcGtpLmpsYWIub3JnLzIwMTYv
+QUlBL0pMYWJDQS5jcnQwJQYIKwYBBQUHMAGGGWh0dHA6Ly9vY3NwLmpsYWIub3Jn
+L29jc3AwDQYJKoZIhvcNAQENBQADggIBADtpOoVOl068/+ntxZ/k5lZzjItNVzTY
+EQB5Y4N8YaxvJCD3N6a0ltxis81dCQxSdT0CfbZAygy+6n2xeTfJ24xQ2YsjWW0F
+gji/MUunXzrdCjdf2zGiPoSDmBByVTT/ndO4ZxW5twn3KgxjoJ1DFfXuG2QpYZnr
+CmCmq7VHPSpyFZXhgyQgSYpU0pdnDuQWi7D2RXuLIFztcTWJWi6R2k7UXfjeZpo9
+JieGDqcE+rJL3dgzI8VSXeTc+zePmDVojDIlFjIJ5pyj5uxYdrI3q5onPpcRIxlx
+CjQJI+p4jjxqORlVcT813b231N7EndhCZJpocl0FpMdGt4erx+jAzJo5Zr2OhSqO
+MS03ChZBbugWj5iexm/ryFfcGfe5NbyqB59fwkmWGZliSob6VOn6rslP8XSD2OxV
+8qHf3JNmJgMBBp/1NGKLp1hDHy6j8DEk1+z/XMRaelqbOYoDRbYr5NiwZQaaTj3e
+OAYkFsTzJdoC/mc4P8ydEvWzj5RxUv46qXmtOj/6Gb4z+jZgY4Atl/tF0BIwGaAE
+pbUVLj/QqgagyfdcSal99uyde9a0V06GyiXRwlxU7bWAd9huc1U92B9pWxc0cN4m
+A0KhI8SuCAlSXw1JnM3V3kJRhX7jmkClRViIu3RmxV4U2OZZVOpL1gl1Ig+jheqq
+kpRrfL83dPma
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 4 (0x4)
+    Signature Algorithm: sha512WithRSAEncryption
+        Issuer: C=US, ST=Virginia, L=Newport News, O=Jefferson Lab, OU=IT-CNI, CN=JLabCA
+        Validity
+            Not Before: Aug 16 09:14:58 2016 GMT
+            Not After : Aug 11 09:14:58 2036 GMT
+        Subject: C=US, ST=Virginia, L=Newport News, O=Jefferson Lab, OU=IT-CNI, CN=JLABICA8-JLabGPCA, DC=jlab, DC=org
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (4096 bit)
+                Modulus:
+                    00:b1:ed:6d:a4:a3:35:d0:d9:58:01:8d:14:97:60:
+                    1c:6b:1f:6a:a1:28:a0:a5:ae:b0:3f:88:f9:b7:4f:
+                    37:f1:cc:01:8f:35:d7:4f:8d:f0:6e:04:4a:74:90:
+                    9f:00:93:ed:2e:58:42:eb:4f:95:d3:97:17:4d:ad:
+                    f0:e9:d4:3c:65:3f:59:cd:b2:6f:58:c9:78:d2:1c:
+                    87:0d:ce:73:b3:1f:18:c4:84:74:a1:aa:eb:74:00:
+                    a1:3e:19:cf:70:4d:b7:65:67:0b:85:d6:8f:4d:80:
+                    34:61:53:94:3e:21:aa:c8:82:88:07:84:ab:8e:db:
+                    ac:d0:c4:14:33:a6:76:24:0b:65:ee:dc:c8:ac:25:
+                    22:04:e6:9d:b5:77:93:b8:07:74:d9:b9:4c:ff:32:
+                    5d:89:f4:00:1d:07:48:02:39:50:22:73:69:bc:ea:
+                    f2:cb:e0:67:58:ec:94:fa:d6:ea:2a:96:e2:f1:18:
+                    a4:72:3e:a5:a7:a5:bc:8c:9f:ac:3c:f9:f2:23:f1:
+                    7a:e1:c0:32:f8:f6:56:a2:63:15:25:43:94:b8:4c:
+                    f6:e4:c8:62:65:1a:b8:2c:ae:a6:ca:85:b2:1a:05:
+                    a2:d9:96:68:98:20:b9:85:3a:c6:fc:8c:84:f1:66:
+                    98:18:d6:0f:d6:28:b6:b2:da:44:05:bf:5b:ce:5a:
+                    f5:03:c5:a1:e4:8f:a7:49:cf:55:ea:a0:0e:d8:a6:
+                    fc:23:ba:cd:fc:30:38:9e:67:be:02:68:c5:cd:ac:
+                    7e:45:95:65:dd:b2:9f:6b:9e:4c:60:26:b8:7c:7a:
+                    e4:9b:f2:6c:c1:5a:f4:43:e1:63:d0:b3:a3:fd:67:
+                    5d:44:d5:02:87:3d:9a:eb:c4:48:4e:6f:bf:6f:4b:
+                    3e:4d:32:42:45:05:25:0e:32:b1:e2:19:56:a8:d4:
+                    d7:01:77:f0:60:08:be:d3:e2:7f:c7:82:83:a7:69:
+                    aa:86:d8:fe:f9:70:ae:ff:3f:2e:a5:12:64:35:d5:
+                    5b:a8:0e:6b:6e:8f:88:b6:c5:aa:0c:12:0c:40:f2:
+                    e2:bc:16:de:66:a7:13:44:04:6d:e9:ab:be:06:c6:
+                    b0:1c:c9:74:65:be:90:b3:17:64:32:83:e2:46:77:
+                    14:04:6d:32:15:e7:43:1a:4e:93:34:a5:4d:68:ed:
+                    3c:82:84:02:74:a0:89:79:e6:7d:0f:95:01:17:bb:
+                    c8:c6:f4:e0:fe:5c:72:15:f0:d6:a8:de:50:ba:c3:
+                    01:98:83:6f:56:0b:95:05:61:f4:dd:10:44:f2:6e:
+                    59:c3:02:0a:da:da:ae:21:56:c0:61:c2:53:ee:56:
+                    7c:b7:d2:39:a6:1b:1e:a2:cf:ab:06:6b:10:96:3f:
+                    3a:ec:a9
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:9
+            X509v3 Subject Key Identifier: 
+                A7:F5:68:39:41:45:CA:08:C6:F4:0B:A9:CA:E8:B4:E1:FA:E0:31:D5
+            X509v3 Authority Key Identifier: 
+                keyid:70:BC:0B:31:47:25:C2:18:86:4E:00:E4:2F:47:C6:BD:EE:BA:5F:ED
+                DirName:/C=US/ST=Virginia/L=Newport News/O=Jefferson Lab/OU=IT-CNI/CN=JLabCA
+                serial:83:AB:95:EF:27:E2:4E:9D
+
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://pki.jlab.org/2016/JLabCA.crl
+
+            Authority Information Access: 
+                CA Issuers - URI:http://pki.jlab.org/2016/AIA/JLabCA.crt
+                OCSP - URI:http://ocsp.jlab.org/ocsp
+
+    Signature Algorithm: sha512WithRSAEncryption
+         97:f9:6b:de:98:76:e2:ab:8b:36:e6:dc:ef:d9:06:03:6b:a5:
+         74:f8:76:60:57:41:a3:c6:f8:29:50:bc:ca:0d:d8:bb:d9:e5:
+         09:6e:76:77:d2:23:d2:d7:51:96:8d:a1:91:09:14:cb:02:f4:
+         9d:b3:f2:64:74:52:97:70:be:8b:01:12:11:9b:f5:38:da:18:
+         a7:31:a5:ed:1d:be:72:43:85:9e:ba:f4:3a:e8:d8:5e:35:bf:
+         48:72:6a:ae:a5:96:03:1b:14:51:06:09:9d:63:bd:41:e1:45:
+         2e:f9:0b:bc:08:58:6f:44:f1:8c:fd:bc:29:b7:9e:fe:10:e5:
+         96:f8:c9:c6:da:67:0d:16:27:81:76:48:9f:c0:83:2b:2d:64:
+         35:ba:bd:88:1d:80:3f:2b:e9:4d:45:b4:28:17:06:59:a8:76:
+         60:98:88:03:f8:28:3e:55:39:ba:63:1f:aa:03:b1:2f:e8:34:
+         fc:f5:f2:ed:14:90:79:7c:66:5e:dd:f4:c9:bf:22:73:10:b4:
+         0f:ad:a4:6a:36:da:de:f1:45:50:16:37:2e:d1:3d:e4:2f:51:
+         0d:6f:9e:6b:bc:37:12:77:25:fc:8f:97:d0:b5:6f:50:5e:f7:
+         f8:17:8d:d7:d5:de:cc:24:79:97:c2:9f:47:ef:dd:cb:7e:84:
+         5a:c5:7f:5a:5f:12:e5:b7:0f:4c:89:a6:1b:d5:7d:40:ef:f5:
+         2c:33:67:e0:a5:30:d8:ab:3f:f4:1b:97:7b:c4:71:bc:fe:fb:
+         8e:c8:e6:a1:74:97:89:b0:cd:18:88:dc:f9:9d:51:50:91:7b:
+         66:21:2d:b5:cc:dd:22:77:3a:02:7e:9f:e4:2d:a4:db:bd:39:
+         4b:28:af:c6:a2:8e:c9:66:e9:0f:01:d6:cd:47:56:33:75:5c:
+         43:4c:72:c4:b5:4d:6b:53:f3:26:b8:8c:9f:e0:c1:13:2c:f1:
+         e9:5b:a2:81:ed:ef:f3:fc:d0:70:08:6c:fa:da:fb:35:a0:00:
+         cc:b1:a0:fb:d3:03:c0:8c:83:dd:fd:1e:ff:0a:3d:10:49:fb:
+         aa:81:67:33:8e:8e:9c:8c:d4:22:ae:bb:d4:d1:74:72:13:66:
+         3c:78:d9:67:b7:17:04:2c:f8:53:6c:86:21:b3:95:e5:45:bc:
+         94:3b:20:4e:74:c2:15:81:21:dd:ec:53:5b:ed:c4:0c:95:53:
+         b2:95:c0:f7:51:82:5e:f9:9c:70:86:f0:c5:b2:c4:96:f3:26:
+         81:97:55:c3:3d:72:a2:98:99:6d:71:bb:16:6e:f3:21:95:c0:
+         58:30:d5:dc:db:53:a0:0c:ef:60:97:14:2e:b2:3c:62:8e:1d:
+         8a:9d:e0:cc:0d:40:2e:9a
+-----BEGIN CERTIFICATE-----
+MIIHJTCCBQ2gAwIBAgIBBDANBgkqhkiG9w0BAQ0FADBxMQswCQYDVQQGEwJVUzER
+MA8GA1UECBMIVmlyZ2luaWExFTATBgNVBAcTDE5ld3BvcnQgTmV3czEWMBQGA1UE
+ChMNSmVmZmVyc29uIExhYjEPMA0GA1UECxMGSVQtQ05JMQ8wDQYDVQQDEwZKTGFi
+Q0EwHhcNMTYwODE2MDkxNDU4WhcNMzYwODExMDkxNDU4WjCBpzELMAkGA1UEBhMC
+VVMxETAPBgNVBAgTCFZpcmdpbmlhMRUwEwYDVQQHEwxOZXdwb3J0IE5ld3MxFjAU
+BgNVBAoTDUplZmZlcnNvbiBMYWIxDzANBgNVBAsTBklULUNOSTEaMBgGA1UEAxMR
+SkxBQklDQTgtSkxhYkdQQ0ExFDASBgoJkiaJk/IsZAEZFgRqbGFiMRMwEQYKCZIm
+iZPyLGQBGRYDb3JnMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAse1t
+pKM10NlYAY0Ul2Acax9qoSigpa6wP4j5t0838cwBjzXXT43wbgRKdJCfAJPtLlhC
+60+V05cXTa3w6dQ8ZT9ZzbJvWMl40hyHDc5zsx8YxIR0oarrdAChPhnPcE23ZWcL
+hdaPTYA0YVOUPiGqyIKIB4Srjtus0MQUM6Z2JAtl7tzIrCUiBOadtXeTuAd02blM
+/zJdifQAHQdIAjlQInNpvOryy+BnWOyU+tbqKpbi8Rikcj6lp6W8jJ+sPPnyI/F6
+4cAy+PZWomMVJUOUuEz25MhiZRq4LK6myoWyGgWi2ZZomCC5hTrG/IyE8WaYGNYP
+1ii2stpEBb9bzlr1A8Wh5I+nSc9V6qAO2Kb8I7rN/DA4nme+AmjFzax+RZVl3bKf
+a55MYCa4fHrkm/JswVr0Q+Fj0LOj/WddRNUChz2a68RITm+/b0s+TTJCRQUlDjKx
+4hlWqNTXAXfwYAi+0+J/x4KDp2mqhtj++XCu/z8upRJkNdVbqA5rbo+ItsWqDBIM
+QPLivBbeZqcTRARt6au+BsawHMl0Zb6QsxdkMoPiRncUBG0yFedDGk6TNKVNaO08
+goQCdKCJeeZ9D5UBF7vIxvTg/lxyFfDWqN5QusMBmINvVguVBWH03RBE8m5ZwwIK
+2tquIVbAYcJT7lZ8t9I5phseos+rBmsQlj867KkCAwEAAaOCAY8wggGLMBIGA1Ud
+EwEB/wQIMAYBAf8CAQkwHQYDVR0OBBYEFKf1aDlBRcoIxvQLqcrotOH64DHVMIGj
+BgNVHSMEgZswgZiAFHC8CzFHJcIYhk4A5C9Hxr3uul/toXWkczBxMQswCQYDVQQG
+EwJVUzERMA8GA1UECBMIVmlyZ2luaWExFTATBgNVBAcTDE5ld3BvcnQgTmV3czEW
+MBQGA1UEChMNSmVmZmVyc29uIExhYjEPMA0GA1UECxMGSVQtQ05JMQ8wDQYDVQQD
+EwZKTGFiQ0GCCQCDq5XvJ+JOnTAOBgNVHQ8BAf8EBAMCAQYwNAYDVR0fBC0wKzAp
+oCegJYYjaHR0cDovL3BraS5qbGFiLm9yZy8yMDE2L0pMYWJDQS5jcmwwagYIKwYB
+BQUHAQEEXjBcMDMGCCsGAQUFBzAChidodHRwOi8vcGtpLmpsYWIub3JnLzIwMTYv
+QUlBL0pMYWJDQS5jcnQwJQYIKwYBBQUHMAGGGWh0dHA6Ly9vY3NwLmpsYWIub3Jn
+L29jc3AwDQYJKoZIhvcNAQENBQADggIBAJf5a96YduKrizbm3O/ZBgNrpXT4dmBX
+QaPG+ClQvMoN2LvZ5QludnfSI9LXUZaNoZEJFMsC9J2z8mR0UpdwvosBEhGb9Tja
+GKcxpe0dvnJDhZ669Dro2F41v0hyaq6llgMbFFEGCZ1jvUHhRS75C7wIWG9E8Yz9
+vCm3nv4Q5Zb4ycbaZw0WJ4F2SJ/AgystZDW6vYgdgD8r6U1FtCgXBlmodmCYiAP4
+KD5VObpjH6oDsS/oNPz18u0UkHl8Zl7d9Mm/InMQtA+tpGo22t7xRVAWNy7RPeQv
+UQ1vnmu8NxJ3JfyPl9C1b1Be9/gXjdfV3swkeZfCn0fv3ct+hFrFf1pfEuW3D0yJ
+phvVfUDv9SwzZ+ClMNirP/Qbl3vEcbz++47I5qF0l4mwzRiI3PmdUVCRe2YhLbXM
+3SJ3OgJ+n+QtpNu9OUsor8aijslm6Q8B1s1HVjN1XENMcsS1TWtT8ya4jJ/gwRMs
+8elbooHt7/P80HAIbPra+zWgAMyxoPvTA8CMg939Hv8KPRBJ+6qBZzOOjpyM1CKu
+u9TRdHITZjx42We3FwQs+FNshiGzleVFvJQ7IE50whWBId3sU1vtxAyVU7KVwPdR
+gl75nHCG8MWyxJbzJoGXVcM9cqKYmW1xuxZu8yGVwFgw1dzbU6AM72CXFC6yPGKO
+HYqd4MwNQC6a
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 5 (0x5)
+    Signature Algorithm: sha512WithRSAEncryption
+        Issuer: C=US, ST=Virginia, L=Newport News, O=Jefferson Lab, OU=IT-CNI, CN=JLabCA
+        Validity
+            Not Before: Aug 16 09:15:28 2016 GMT
+            Not After : Aug 11 09:15:28 2036 GMT
+        Subject: C=US, ST=Virginia, L=Newport News, O=Jefferson Lab, OU=IT-CNI, CN=JLABICA9-JLabSCCA, DC=jlab, DC=org
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (4096 bit)
+                Modulus:
+                    00:be:0f:fd:2d:1a:fa:09:83:1f:52:e2:fc:f1:5a:
+                    63:f3:0d:0f:14:2a:8c:74:76:27:f0:49:b2:c6:21:
+                    c2:3c:fb:77:d8:d9:a1:d3:2c:55:9c:cd:17:ef:f8:
+                    75:cb:71:09:98:40:cc:a7:f6:e1:e5:91:08:35:ef:
+                    f7:17:d3:71:24:f2:44:67:d2:6f:01:b8:49:db:85:
+                    03:c2:eb:54:4a:51:82:38:8b:93:3d:f0:48:45:36:
+                    07:b2:1e:ba:20:35:e0:73:e3:7c:ee:59:0b:5c:91:
+                    49:c0:dd:21:c5:84:57:a2:f2:45:39:d8:a1:45:0d:
+                    25:16:7d:10:39:de:63:7a:95:f0:1e:19:97:f0:3a:
+                    a8:aa:9c:f9:d2:13:24:da:85:c6:d1:f4:68:d3:a3:
+                    e7:59:9e:78:d1:18:fa:fa:90:8b:db:06:e7:a0:b1:
+                    af:f3:dc:c3:a3:0e:cd:82:fa:12:8f:85:fa:92:e0:
+                    88:02:a6:49:30:3f:4c:1c:4e:77:02:7d:1d:bf:ff:
+                    45:52:8a:96:bb:ca:a8:74:a4:b1:14:88:36:0d:6d:
+                    07:36:3c:24:16:6d:2e:f2:f9:17:1f:c8:f5:25:91:
+                    cd:a0:b0:90:ac:3f:f6:33:0f:34:72:2b:af:dc:38:
+                    52:26:fc:1c:19:b0:a3:35:87:fc:05:e5:21:2e:d4:
+                    b4:00:11:5d:e3:6b:7b:f7:03:1b:43:89:e9:8c:f1:
+                    c0:6c:ae:3f:f2:33:d5:b1:28:8b:93:c1:7d:4b:17:
+                    a7:96:3f:09:e3:65:07:db:01:7a:78:dc:aa:48:e5:
+                    c2:f3:e0:6a:0a:3a:13:5c:20:62:f2:aa:21:81:0b:
+                    05:69:74:90:cc:a9:ad:77:3e:29:1c:04:4f:a9:b6:
+                    99:46:bd:bb:d7:42:5e:67:2d:0d:08:c9:56:4f:e2:
+                    e4:45:8b:fb:c5:c8:24:7a:69:ec:28:45:f2:f6:8b:
+                    9f:f5:e3:db:64:1e:68:9e:01:b3:3e:55:69:7f:26:
+                    c6:10:bc:c2:43:23:b4:2c:5b:bf:5b:37:69:fd:8c:
+                    b2:ae:55:b7:62:66:34:55:e4:e2:a5:4c:60:b1:aa:
+                    35:2f:6d:8a:83:ba:df:37:db:b2:50:1a:29:13:58:
+                    a5:64:16:7d:8e:73:0f:92:6a:c8:91:20:ca:86:2c:
+                    46:d8:62:4c:36:57:34:e5:90:9c:b6:68:b5:91:cc:
+                    4a:ef:19:e0:08:ee:5e:c8:82:78:7c:df:01:d5:f4:
+                    2b:00:c0:fc:6c:a4:b7:cb:0a:40:62:82:10:2c:17:
+                    88:ba:1e:90:63:d7:fe:24:72:64:c9:0c:c1:8c:5b:
+                    f9:20:44:46:06:00:8b:33:57:17:68:b0:7b:c6:11:
+                    0b:1a:7f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:9
+            X509v3 Subject Key Identifier: 
+                0A:38:39:30:FC:0A:21:30:A8:B0:15:FF:7F:B4:E7:76:CE:92:05:3C
+            X509v3 Authority Key Identifier: 
+                keyid:70:BC:0B:31:47:25:C2:18:86:4E:00:E4:2F:47:C6:BD:EE:BA:5F:ED
+                DirName:/C=US/ST=Virginia/L=Newport News/O=Jefferson Lab/OU=IT-CNI/CN=JLabCA
+                serial:83:AB:95:EF:27:E2:4E:9D
+
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://pki.jlab.org/2016/JLabCA.crl
+
+            Authority Information Access: 
+                CA Issuers - URI:http://pki.jlab.org/2016/AIA/JLabCA.crt
+                OCSP - URI:http://ocsp.jlab.org/ocsp
+
+    Signature Algorithm: sha512WithRSAEncryption
+         8f:38:88:ba:3f:4d:6e:d8:5e:e7:5c:c1:7c:41:ff:32:39:7a:
+         39:85:c7:1e:05:9a:dc:20:6f:0f:ef:b2:2f:55:a4:ff:98:15:
+         3e:d6:52:da:b8:d9:0c:af:e5:c2:92:52:8b:00:96:65:5b:e2:
+         94:90:61:e3:2d:9d:e3:41:f9:4b:49:ff:a3:83:f2:89:b9:f5:
+         5f:1a:e1:67:4f:f8:62:4f:0b:f0:e1:9b:54:25:ca:23:27:66:
+         d3:cd:a3:da:d0:87:c6:1e:a4:c4:21:31:f2:43:13:5e:24:72:
+         10:d7:d4:36:9e:7b:a3:ca:e2:41:d8:84:cd:fb:84:2a:4b:e8:
+         ab:99:77:9a:4d:4d:3f:7d:1a:8c:ab:be:b9:01:7e:22:31:99:
+         96:84:32:87:fd:9d:71:26:81:f8:95:1e:9e:6d:0c:65:8e:95:
+         bc:13:9a:04:bf:6b:64:40:1d:ed:d0:f3:6a:5f:e7:72:bf:a3:
+         5f:bc:25:9b:8a:ac:f2:4e:fc:89:00:f2:08:da:bb:e9:57:4e:
+         87:01:43:85:54:35:c5:13:cc:51:19:17:d5:73:8d:4e:3c:14:
+         44:91:8c:02:85:03:f2:4b:7f:8a:57:36:99:7a:98:5a:74:ec:
+         0c:31:fd:c2:46:64:3e:22:4d:39:ad:f6:c5:7e:e2:f7:04:3d:
+         62:1a:3c:ec:3e:7a:32:b0:f4:f9:83:2f:6c:09:dc:38:c4:56:
+         88:24:9e:18:40:c2:42:f9:a9:a6:13:c5:b0:dc:b3:76:92:49:
+         7e:1c:b4:34:ea:03:2d:09:97:ea:1c:ba:97:a0:36:b5:8f:bb:
+         8f:0d:7c:28:e2:50:63:03:c3:a7:96:60:ca:97:58:38:a0:c7:
+         ed:e3:13:c4:42:c2:3b:75:51:3c:0d:3a:e1:be:5c:82:28:4d:
+         61:4b:9b:ab:0f:36:ba:ef:05:e6:e5:f4:8a:a0:3f:cf:00:43:
+         2f:14:58:57:53:db:60:5e:a0:84:df:04:f8:5e:fc:ef:38:43:
+         da:cb:35:94:76:7c:0c:50:0f:9b:21:2b:79:3b:9e:df:bd:16:
+         c4:27:ef:43:81:09:18:6a:ad:7a:ef:16:bf:e7:66:c9:b2:6e:
+         99:9f:a8:8d:34:8b:15:40:c3:4f:ee:6c:34:bb:7f:52:38:23:
+         bd:4b:55:99:60:a7:09:ae:ab:47:59:1d:c0:fd:ac:d0:0b:8a:
+         37:06:4f:d4:95:2a:82:bd:ed:f8:40:fa:51:47:f6:39:70:69:
+         b9:51:3e:ea:c0:ab:d0:38:d1:c9:d1:2d:ac:25:e0:79:82:c8:
+         ac:de:b4:fb:06:8d:44:e1:90:9d:9a:c4:99:8b:57:55:23:2f:
+         52:0b:78:7e:c0:0e:8b:92
+-----BEGIN CERTIFICATE-----
+MIIHJTCCBQ2gAwIBAgIBBTANBgkqhkiG9w0BAQ0FADBxMQswCQYDVQQGEwJVUzER
+MA8GA1UECBMIVmlyZ2luaWExFTATBgNVBAcTDE5ld3BvcnQgTmV3czEWMBQGA1UE
+ChMNSmVmZmVyc29uIExhYjEPMA0GA1UECxMGSVQtQ05JMQ8wDQYDVQQDEwZKTGFi
+Q0EwHhcNMTYwODE2MDkxNTI4WhcNMzYwODExMDkxNTI4WjCBpzELMAkGA1UEBhMC
+VVMxETAPBgNVBAgTCFZpcmdpbmlhMRUwEwYDVQQHEwxOZXdwb3J0IE5ld3MxFjAU
+BgNVBAoTDUplZmZlcnNvbiBMYWIxDzANBgNVBAsTBklULUNOSTEaMBgGA1UEAxMR
+SkxBQklDQTktSkxhYlNDQ0ExFDASBgoJkiaJk/IsZAEZFgRqbGFiMRMwEQYKCZIm
+iZPyLGQBGRYDb3JnMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAvg/9
+LRr6CYMfUuL88Vpj8w0PFCqMdHYn8EmyxiHCPPt32Nmh0yxVnM0X7/h1y3EJmEDM
+p/bh5ZEINe/3F9NxJPJEZ9JvAbhJ24UDwutUSlGCOIuTPfBIRTYHsh66IDXgc+N8
+7lkLXJFJwN0hxYRXovJFOdihRQ0lFn0QOd5jepXwHhmX8Dqoqpz50hMk2oXG0fRo
+06PnWZ540Rj6+pCL2wbnoLGv89zDow7NgvoSj4X6kuCIAqZJMD9MHE53An0dv/9F
+UoqWu8qodKSxFIg2DW0HNjwkFm0u8vkXH8j1JZHNoLCQrD/2Mw80ciuv3DhSJvwc
+GbCjNYf8BeUhLtS0ABFd42t79wMbQ4npjPHAbK4/8jPVsSiLk8F9Sxenlj8J42UH
+2wF6eNyqSOXC8+BqCjoTXCBi8qohgQsFaXSQzKmtdz4pHARPqbaZRr2710JeZy0N
+CMlWT+LkRYv7xcgkemnsKEXy9ouf9ePbZB5ongGzPlVpfybGELzCQyO0LFu/Wzdp
+/YyyrlW3YmY0VeTipUxgsao1L22Kg7rfN9uyUBopE1ilZBZ9jnMPkmrIkSDKhixG
+2GJMNlc05ZCctmi1kcxK7xngCO5eyIJ4fN8B1fQrAMD8bKS3ywpAYoIQLBeIuh6Q
+Y9f+JHJkyQzBjFv5IERGBgCLM1cXaLB7xhELGn8CAwEAAaOCAY8wggGLMBIGA1Ud
+EwEB/wQIMAYBAf8CAQkwHQYDVR0OBBYEFAo4OTD8CiEwqLAV/3+053bOkgU8MIGj
+BgNVHSMEgZswgZiAFHC8CzFHJcIYhk4A5C9Hxr3uul/toXWkczBxMQswCQYDVQQG
+EwJVUzERMA8GA1UECBMIVmlyZ2luaWExFTATBgNVBAcTDE5ld3BvcnQgTmV3czEW
+MBQGA1UEChMNSmVmZmVyc29uIExhYjEPMA0GA1UECxMGSVQtQ05JMQ8wDQYDVQQD
+EwZKTGFiQ0GCCQCDq5XvJ+JOnTAOBgNVHQ8BAf8EBAMCAQYwNAYDVR0fBC0wKzAp
+oCegJYYjaHR0cDovL3BraS5qbGFiLm9yZy8yMDE2L0pMYWJDQS5jcmwwagYIKwYB
+BQUHAQEEXjBcMDMGCCsGAQUFBzAChidodHRwOi8vcGtpLmpsYWIub3JnLzIwMTYv
+QUlBL0pMYWJDQS5jcnQwJQYIKwYBBQUHMAGGGWh0dHA6Ly9vY3NwLmpsYWIub3Jn
+L29jc3AwDQYJKoZIhvcNAQENBQADggIBAI84iLo/TW7YXudcwXxB/zI5ejmFxx4F
+mtwgbw/vsi9VpP+YFT7WUtq42Qyv5cKSUosAlmVb4pSQYeMtneNB+UtJ/6OD8om5
+9V8a4WdP+GJPC/Dhm1QlyiMnZtPNo9rQh8YepMQhMfJDE14kchDX1Daee6PK4kHY
+hM37hCpL6KuZd5pNTT99GoyrvrkBfiIxmZaEMof9nXEmgfiVHp5tDGWOlbwTmgS/
+a2RAHe3Q82pf53K/o1+8JZuKrPJO/IkA8gjau+lXTocBQ4VUNcUTzFEZF9VzjU48
+FESRjAKFA/JLf4pXNpl6mFp07Awx/cJGZD4iTTmt9sV+4vcEPWIaPOw+ejKw9PmD
+L2wJ3DjEVogknhhAwkL5qaYTxbDcs3aSSX4ctDTqAy0Jl+ocupegNrWPu48NfCji
+UGMDw6eWYMqXWDigx+3jE8RCwjt1UTwNOuG+XIIoTWFLm6sPNrrvBebl9IqgP88A
+Qy8UWFdT22BeoITfBPhe/O84Q9rLNZR2fAxQD5shK3k7nt+9FsQn70OBCRhqrXrv
+Fr/nZsmybpmfqI00ixVAw0/ubDS7f1I4I71LVZlgpwmuq0dZHcD9rNALijcGT9SV
+KoK97fhA+lFH9jlwablRPurAq9A40cnRLawl4HmCyKzetPsGjUThkJ2axJmLV1Uj
+L1ILeH7ADouS
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 16435159226528884306 (0xe4156a3d443ce652)
+    Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, ST=North Carolina, L=Raleigh, O=Katello, OU=SomeOrgUnit, CN=jlabrhn.jlab.org
+        Validity
+            Not Before: Jul 14 14:26:23 2017 GMT
+            Not After : Jan 18 14:26:23 2038 GMT
+        Subject: C=US, ST=North Carolina, L=Raleigh, O=Katello, OU=SomeOrgUnit, CN=jlabrhn.jlab.org
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:e2:4b:17:7e:56:03:d2:dc:55:d9:26:6b:66:0b:
+                    57:dd:62:1c:59:3e:1e:80:04:95:86:ee:19:fa:b5:
+                    be:d5:91:f9:4f:b4:55:be:1a:a6:15:b6:11:b0:54:
+                    02:e6:00:f5:0b:52:c9:8c:ed:4c:e8:02:18:52:84:
+                    bf:cf:e4:44:33:0e:f8:c1:11:3b:06:04:e2:05:0b:
+                    29:80:27:0c:1b:04:84:a0:d8:56:9d:79:fc:b2:1f:
+                    0b:59:8c:94:bd:f4:e7:73:4f:f9:fa:cd:80:10:6a:
+                    8d:d0:db:33:b4:ec:59:c0:1f:67:ee:b6:4f:bb:f8:
+                    3c:2b:16:b4:ed:2d:3a:4f:66:b9:66:f6:82:a9:3b:
+                    78:0d:ac:c3:14:22:66:65:7f:0f:35:5c:7d:b2:ae:
+                    b7:27:38:39:18:5f:f7:bb:b2:d9:0e:d6:fb:bd:38:
+                    e3:74:60:07:49:79:d3:cc:0d:cc:c0:88:a3:94:f2:
+                    29:40:8d:03:9d:30:45:f6:aa:97:83:aa:0a:4f:0e:
+                    5b:42:08:d0:d8:dd:b6:d4:92:4a:fc:4c:2e:15:8b:
+                    20:7e:3b:66:dc:f2:ea:04:c1:65:54:ba:04:3c:10:
+                    13:3b:c8:30:3c:0a:c7:da:a9:ce:76:a9:11:00:bc:
+                    f8:52:bb:7c:77:c0:0f:9f:f4:ce:73:b0:d3:fc:5d:
+                    cf:39
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints: 
+                CA:TRUE
+            X509v3 Key Usage: 
+                Digital Signature, Key Encipherment, Certificate Sign, CRL Sign
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            Netscape Cert Type: 
+                SSL Server, SSL CA
+            Netscape Comment: 
+                Katello SSL Tool Generated Certificate
+            X509v3 Subject Key Identifier: 
+                E6:7F:B3:91:20:92:D4:02:E0:BC:EA:D4:B4:86:DD:E8:AA:60:26:D7
+            X509v3 Authority Key Identifier: 
+                keyid:E6:7F:B3:91:20:92:D4:02:E0:BC:EA:D4:B4:86:DD:E8:AA:60:26:D7
+                DirName:/C=US/ST=North Carolina/L=Raleigh/O=Katello/OU=SomeOrgUnit/CN=jlabrhn.jlab.org
+                serial:E4:15:6A:3D:44:3C:E6:52
+
+    Signature Algorithm: sha256WithRSAEncryption
+         b4:1e:97:54:27:ce:c8:19:5d:e5:96:78:0b:6f:94:4a:60:c8:
+         89:a0:65:79:c4:75:41:d2:af:b2:84:e5:c6:fe:fb:a2:2d:dc:
+         de:f2:5e:63:4a:a5:da:64:e7:74:7f:7e:e1:34:02:8e:22:2a:
+         00:27:10:39:20:d2:5d:98:04:30:64:15:6b:3e:44:89:9e:5b:
+         e4:78:63:22:6d:cf:03:53:d0:5f:04:85:0b:64:f8:ac:b2:ba:
+         b2:ea:07:34:db:0f:88:ac:f4:36:c2:1c:f8:41:2e:54:80:df:
+         15:d7:fa:93:e8:13:5d:31:9d:eb:3a:f5:b0:4a:9b:fc:31:42:
+         a9:65:5c:1b:6e:f1:d5:87:bf:e4:bc:6a:2e:94:7c:49:79:61:
+         fb:15:73:c6:d1:8f:3f:ab:02:28:27:98:49:29:07:c7:2a:2f:
+         6e:6d:b6:e6:6c:a6:75:19:6d:3c:08:b1:45:10:e6:6e:f6:cd:
+         b1:ba:02:48:2b:2d:4c:d2:86:50:f9:5f:83:f1:0e:c3:89:80:
+         7d:66:4e:2c:fa:78:e5:a7:3f:34:a1:e3:71:21:e4:cc:aa:44:
+         36:3e:a5:a5:18:af:78:bc:2c:46:43:a0:ca:15:d9:43:70:51:
+         a4:8b:4d:7e:a7:9d:4d:b0:f0:6c:4d:3d:1f:aa:03:0d:04:5e:
+         44:9e:5f:bd
+-----BEGIN CERTIFICATE-----
+MIIE0jCCA7qgAwIBAgIJAOQVaj1EPOZSMA0GCSqGSIb3DQEBCwUAMHsxCzAJBgNV
+BAYTAlVTMRcwFQYDVQQIEw5Ob3J0aCBDYXJvbGluYTEQMA4GA1UEBxMHUmFsZWln
+aDEQMA4GA1UEChMHS2F0ZWxsbzEUMBIGA1UECxMLU29tZU9yZ1VuaXQxGTAXBgNV
+BAMTEGpsYWJyaG4uamxhYi5vcmcwHhcNMTcwNzE0MTQyNjIzWhcNMzgwMTE4MTQy
+NjIzWjB7MQswCQYDVQQGEwJVUzEXMBUGA1UECBMOTm9ydGggQ2Fyb2xpbmExEDAO
+BgNVBAcTB1JhbGVpZ2gxEDAOBgNVBAoTB0thdGVsbG8xFDASBgNVBAsTC1NvbWVP
+cmdVbml0MRkwFwYDVQQDExBqbGFicmhuLmpsYWIub3JnMIIBIjANBgkqhkiG9w0B
+AQEFAAOCAQ8AMIIBCgKCAQEA4ksXflYD0txV2SZrZgtX3WIcWT4egASVhu4Z+rW+
+1ZH5T7RVvhqmFbYRsFQC5gD1C1LJjO1M6AIYUoS/z+REMw74wRE7BgTiBQspgCcM
+GwSEoNhWnXn8sh8LWYyUvfTnc0/5+s2AEGqN0NsztOxZwB9n7rZPu/g8Kxa07S06
+T2a5ZvaCqTt4DazDFCJmZX8PNVx9sq63Jzg5GF/3u7LZDtb7vTjjdGAHSXnTzA3M
+wIijlPIpQI0DnTBF9qqXg6oKTw5bQgjQ2N221JJK/EwuFYsgfjtm3PLqBMFlVLoE
+PBATO8gwPArH2qnOdqkRALz4Urt8d8APn/TOc7DT/F3POQIDAQABo4IBVzCCAVMw
+DAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMCAaYwHQYDVR0lBBYwFAYIKwYBBQUHAwEG
+CCsGAQUFBwMCMBEGCWCGSAGG+EIBAQQEAwICRDA1BglghkgBhvhCAQ0EKBYmS2F0
+ZWxsbyBTU0wgVG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFOZ/
+s5EgktQC4Lzq1LSG3eiqYCbXMIGtBgNVHSMEgaUwgaKAFOZ/s5EgktQC4Lzq1LSG
+3eiqYCbXoX+kfTB7MQswCQYDVQQGEwJVUzEXMBUGA1UECBMOTm9ydGggQ2Fyb2xp
+bmExEDAOBgNVBAcTB1JhbGVpZ2gxEDAOBgNVBAoTB0thdGVsbG8xFDASBgNVBAsT
+C1NvbWVPcmdVbml0MRkwFwYDVQQDExBqbGFicmhuLmpsYWIub3JnggkA5BVqPUQ8
+5lIwDQYJKoZIhvcNAQELBQADggEBALQel1QnzsgZXeWWeAtvlEpgyImgZXnEdUHS
+r7KE5cb++6It3N7yXmNKpdpk53R/fuE0Ao4iKgAnEDkg0l2YBDBkFWs+RImeW+R4
+YyJtzwNT0F8EhQtk+KyyurLqBzTbD4is9DbCHPhBLlSA3xXX+pPoE10xnes69bBK
+m/wxQqllXBtu8dWHv+S8ai6UfEl5YfsVc8bRjz+rAignmEkpB8cqL25ttuZspnUZ
+bTwIsUUQ5m72zbG6AkgrLUzShlD5X4PxDsOJgH1mTiz6eOWnPzSh43Eh5MyqRDY+
+paUYr3i8LEZDoMoV2UNwUaSLTX6nnU2w8GxNPR+qAw0EXkSeX70=
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIHSDCCBTCgAwIBAgITIQAAArb+T4pnezROugAAAAACtjANBgkqhkiG9w0BAQ0F
+ADCBpzELMAkGA1UEBhMCVVMxETAPBgNVBAgTCFZpcmdpbmlhMRUwEwYDVQQHEwxO
+ZXdwb3J0IE5ld3MxFjAUBgNVBAoTDUplZmZlcnNvbiBMYWIxDzANBgNVBAsTBklU
+LUNOSTEaMBgGA1UEAxMRSkxBQklDQTgtSkxhYkdQQ0ExFDASBgoJkiaJk/IsZAEZ
+FgRqbGFiMRMwEQYKCZImiZPyLGQBGRYDb3JnMB4XDTIyMDMwNDE0MTA0OVoXDTI3
+MDMwNDE0MjA0OVowgZ8xCzAJBgNVBAYTAlVTMREwDwYDVQQIEwhWaXJnaW5pYTEV
+MBMGA1UEBxMMTmV3cG9ydCBOZXdzMRYwFAYDVQQKEw1KZWZmZXJzb24gTGFiMSow
+KAYDVQQLEyFBY2NlbGVyYXRvciBPcGVyYXRpb25zIERlcGFydG1lbnQxIjAgBgNV
+BAMTGUFjY2VsZXJhdG9yIE9wZXJhdGlvbnMgQ0EwggIiMA0GCSqGSIb3DQEBAQUA
+A4ICDwAwggIKAoICAQDEtbkz+eEJ5w166Doh2pbx9ewtWwb5yBno6s502fCU1hoC
+rkLRaPJJRp8+8//D1VtM8cZ12gVcf8lei3CTaiYeGfcY16++zuzS6KMnZw+3QbN+
+7Z8rC6iwwNa+7bs+rV/zRjOJ2Ohv3TPgvW5dGvGuomTylNrqheqwfRdUPXw/KT/y
+Yvg/7veB5aeM+UNxyAbNn48DtA9Su/a1pPoxI4Ptek2UHeRMAGYGOwNPOQdcsP3u
+9lZtGaqz4z/z5Nac0IX6ye88C6i2sbYqJbE5mmWfF5ZVuLzJ2vu+d+T7gF/FYMDa
+rPtaFfNl+GXCvlsnua4yXkuqValimXbyo11X+R297AbHCs6sAHCNuiCuPvrqsaT/
+ibNCVsl22a4AjY2ZnxW3hUOu6TmJUSxG/AwxglXfQ78preuMKvuAA76+hExwsnG+
+TojnrN9Fzc76rsfSdcLQg3YUI+h5OiXVCftRG8yFtyHorpSMcor7l2IPZzum+eFP
+FYB6QKPp1GfeQMd3k+G3ry4xcPmrL+6EU9zw0c9TIQh6rpE5eY7hblOvuIQLQNYy
+WJn1Bfu8cJWN6VPd/dpjsMg3AGAJh1u7piyZo/oyCN24O6tOAOLg3YUMCwpLmYY2
+HDHlQaTGzTDUMyXSBx1pbfkU0TkRvX/8ILBuSm0hIhqAqowpMpndnj3aX4WPwwID
+AQABo4IBcTCCAW0wHQYDVR0OBBYEFJ6N78ioi1kKE2K6+8yBWUgLHU9EMB8GA1Ud
+IwQYMBaAFKf1aDlBRcoIxvQLqcrotOH64DHVMD8GA1UdHwQ4MDYwNKAyoDCGLmh0
+dHA6Ly9wa2kuamxhYi5vcmcvMjAxNi9KTEFCSUNBOC1KTGFiR1BDQS5jcmwwgYcG
+CCsGAQUFBwEBBHsweTBQBggrBgEFBQcwAoZEaHR0cDovL3BraS5qbGFiLm9yZy8y
+MDE2L0FJQS9KTEFCSUNBOC5qbGFiLm9yZ19KTEFCSUNBOC1KTGFiR1BDQS5jcnQw
+JQYIKwYBBQUHMAGGGWh0dHA6Ly9vY3NwLmpsYWIub3JnL29jc3AwEgYDVR0TAQH/
+BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAYYwPAYJKwYBBAGCNxUHBC8wLQYlKwYB
+BAGCNxUI+LQnhseTM4f9mQWC/5Jgha/sfW+Cj5EhhNq0egIBZAIBCzANBgkqhkiG
+9w0BAQ0FAAOCAgEAeq3fgq07WG8JCgOM84RRoHXpGXYp47ErTpLi/Sw28uucivoH
+TBYURKLX4B/xOuKTaIQvlwso+EYl4kqTrUBde2VyEOjjmmcYAzbCMCZJHcKxk3iU
+Xtp5cSrxV2g7QsP7VqgZh+m5KN7K4faQ87z4Mi1bpxnMEgBBgb46n5nxpgkUDyNY
+oRf5lFJKtaYBgVNQY4u4loA/aZS8XCtbNySJLoljS6dt4YGzzevpJWCDGoqYrBob
+e/Rx9ZVnEC9r4QkLQUVFT9B6kQC+pp2VSQCPNqQNowgaZMnSqbBCU825JJn8+sCS
+bEh0TfjnYWPkUSkwrGY9bfuVn4zxOMcdTGJPJbCiz7K/79isyfraZ7RjXa4kxcl+
+HH7u0Qp2QRtYmzsfQHqKSbwZCR2M+gsihILF04cmkw9eh6oz3nJD+XmGwS/7YhtR
+ra21ExDV8/2GvutWUEjWUUuVVTHIUj6ezkPVDS8QNyj9d8d4R7/vG02P9VGd+92I
+JSxtsrBQG0LlU3S81Na6/vfz2oXkh9nA9XY2pqEuOa4N0vg8wSwUGPBmkNMSpQdb
+nrL3197B6lnclHUUpalUjgxpFazvjexQ6hfQc7VzirrdzrvM83il3A8qQZWYMG1x
+e3MNxAEEizPpDSs1Flulk8W6yxPVuo+efCdCEb7bsQ87eR6ZJPHlzVlxyFo=
+-----END CERTIFICATE-----

--- a/scripts/server-setup.sh
+++ b/scripts/server-setup.sh
@@ -97,7 +97,7 @@ EOF
 }
 
 apply_elytron_patch() {
-if [[ -z "${APPLY_ELYTRON_PATCH}}" ]]; then
+if [[ -z "${APPLY_ELYTRON_PATCH}" ]]; then
   echo "Skipping elytron patch because APPLY_ELYTRON_PATCH undefined"
   return 0
 fi
@@ -106,7 +106,7 @@ wget -O "${WILDFLY_APP_HOME}/modules/system/layers/base/org/wildfly/security/ely
 }
 
 config_admin_user() {
-if [[ -z "${APPLY_ELYTRON_PATCH}}" ]]; then
+if [[ -z "${APPLY_ELYTRON_PATCH}" ]]; then
   echo "Skipping config admin because WILDFLY_USER undefined"
   return 0
 fi

--- a/scripts/update-certs-builder.sh
+++ b/scripts/update-certs-builder.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# All arguments are treated as certificates
+CUSTOM_CRT_URL="$@"
+
+if [ -z "${CUSTOM_CRT_URL}" ] ; then
+  echo "No custom certs passed.  Nothing to update"
+  exit 0
+fi
+
+for cert in $CUSTOM_CRT_URL
+do
+  echo Downloading $cert
+  name=$(echo $cert | rev | cut -f1 -d"/" | rev | cut -f1 -d'.') || exit 1
+  wget -O /usr/local/share/ca-certificates/custom-${name}.crt $cert || exit 1
+done
+
+update-ca-certificates || exit 1
+
+for cert in $CUSTOM_CRT_URL
+do
+  echo Importing $cert
+  name=$(echo $cert | rev | cut -f1 -d"/" | rev | cut -f1 -d'.') || exit 1
+  keytool -import -alias custom_${name} -file /usr/local/share/ca-certificates/custom-${name}.crt -cacerts -storepass changeit -noprompt || exit 1
+done
+
+# This line was in the Dockerfile, but I can't tell that it did anything.  Leaving as a reminder.
+# export OPTIONAL_CERT_ARG=--cert=/etc/ssl/certs/ca-certificates.crt || exit 1
+

--- a/scripts/update-certs-runner.sh
+++ b/scripts/update-certs-runner.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# All arguments are treated as certificates
+CUSTOM_CRT_URL="$@"
+
+if [ -z "${CUSTOM_CRT_URL}" ] ; then
+  echo "No custom certs passed.  Nothing to update"
+  exit 0
+fi
+
+for cert in $CUSTOM_CRT_URL
+do
+  echo Downloading $cert
+  name=$(echo $cert | rev | cut -f1 -d"/" | rev | cut -f1 -d'.')
+  curl -sS -o /etc/pki/ca-trust/source/anchors/custom-${name}.crt $cert  || exit 1
+done
+
+update-ca-trust || exit 1
+
+for cert in $CUSTOM_CRT_URL
+do
+  echo Importing $cert
+  name=$(echo $cert | rev | cut -f1 -d"/" | rev | cut -f1 -d'.')
+  keytool -import -alias custom_${name} -file /etc/pki/ca-trust/source/anchors/custom-${name}.crt -cacerts -storepass changeit -noprompt || exit 1
+done


### PR DESCRIPTION
I made a few updates to how custom CA certificates are handled in order to support use case where app in wildfly need to hit HTTPS endpoint in accelerator networks.  Now multiple, space separated custom certificate URLs can be given in the Dockerfile.  These are processed in factored out config scripts that add each certificate to the system trust store.  The builder and runner images each have their own similar script.

As a final step the server now uses the system trust store's cacerts file as it's base keystore unless a custom keystore is passed explicitly to the server-setup.sh script.  By default, I left the JLab Root CA and our accelerator intermediate CA in the final image.  We may want to add additional intermediates to this image as there is no harm and only a convenience gain for downstream users.