### PR TITLE
Add mariadb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea/
+wildfly.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG BUILD_IMAGE=gradle:7.4-jdk17
 ARG RUN_IMAGE=quay.io/wildfly/wildfly:26.1.3.Final-jdk17
 ARG ORACLE_DRIVER_PATH=/ojdbc11-21.7.0.0.jar
+ARG MARIADB_DRIVER_PATH=/mariadb-java-client-3.3.3.jar
 ARG CUSTOM_CRT_URL="https://ace.jlab.org/acc-ca.crt http://pki.jlab.org/JLabCA.crt"
 
 ################## Stage 0
@@ -24,6 +25,7 @@ RUN cd /tmp \
 RUN mkdir /unicopy \
     && cp /app/config/docker-server.env /unicopy \
     && cp /app/scripts/TestOracleConnection.java /unicopy \
+    && cp /app/scripts/TestMariadbConnection.java /unicopy \
     && cp /app/scripts/docker-entrypoint.sh /unicopy \
     && cp /app/scripts/server-setup.sh /unicopy \
     && cp /app/scripts/provided-setup.sh /unicopy \
@@ -35,6 +37,7 @@ FROM ${RUN_IMAGE} as runner
 ARG CUSTOM_CRT_URL
 ARG RUN_USER=jboss:jboss
 ARG ORACLE_DRIVER_PATH
+ARG MARIADB_DRIVER_PATH
 USER root
 COPY --from=builder /unicopy /
 COPY --from=builder /tmp/server.p12 /opt/jboss/wildfly/standalone/configuration
@@ -44,4 +47,5 @@ RUN /update-certs-runner.sh ${CUSTOM_CRT_URL} \
     && rm -rf /opt/jboss/wildfly/standalone/configuration/standalone_xml_history
 ENTRYPOINT ["/docker-entrypoint.sh"]
 ENV ORACLE_DRIVER_PATH=$ORACLE_DRIVER_PATH
+ENV MARIADB_DRIVER_PATH=$MARIADB_DRIVER_PATH
 USER ${RUN_USER}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Configurable [Wildfly](https://www.wildfly.org/) base Docker image and bash setu
 ---
 
 ## Overview
-This Jefferson Lab Wildfly template assumes apps are authenticated with [Keycloak](https://www.keycloak.org/) and use an Oracle database.  Optionally an SMTP mail server can be configured.   The full EE Wildfly distribution is used as a starting point and a few libraries are added including:
+This Jefferson Lab Wildfly template assumes apps are authenticated with [Keycloak](https://www.keycloak.org/) and use an Oracle or MariaDB database.  It is generally expected that only one database will be configured at a time.  Optionally an SMTP mail server can be configured.   The full EE Wildfly distribution is used as a starting point and a few libraries are added including:
 
  - JLog: JLab logbook client
  - Keycloak admin client
@@ -25,22 +25,23 @@ Create a `.env` file for your environment and call the bash scripts [server-setu
 ### Server Setup 
 Only needs to be executed once per permanent installation of Wildfly.
 
-| Name                | Description                                                  |
-|---------------------|--------------------------------------------------------------|
-| ACCESS_LOG          | If defined, enable access logging                            |
-| ADD_JBOSS_MODULES   | JBoss Modules to install, if any                             |
-| APPLY_ELTRON_PATCH  | If defined, apply [patch](https://github.com/slominskir/wildfly-elytron/releases/tag/v1.19.1.Patch1) |
-| EMAIL_FROM          | Default from address for the mail/jlab resource              |
-| EMAIL_HOST          | Host for the mail/jlab resource                              |
-| EMAIL_PORT          | Port for the mail/jlab resource                              |
-| GZIP                | If defined, enable gzip                                      |
-| KEYSTORE_NAME       | If defined, set TLS keystore name (file must be inside configuration dir and of type PKS12) |
-| KEYSTORE_PASS       | Keystore password                                            |
-| ORACLE_DRIVER_URL   | Path to ORACLE Driver for Wildfly to use                     |
-| WILDFLY_HOME        | Path to Wildfly home dir                                     | 
-| WILDFLY_PASS        | Admin password (if empty no admin user is created)           |
-| WILDFLY_RUN_USER    | User for running Wildfly                                     | 
-| WILDFLY_USER        | Admin username (if empty no admin user is created)           |
+| Name               | Description                                                                                          |
+|--------------------|------------------------------------------------------------------------------------------------------|
+| ACCESS_LOG         | If defined, enable access logging                                                                    |
+| ADD_JBOSS_MODULES  | JBoss Modules to install, if any                                                                     |
+| APPLY_ELTRON_PATCH | If defined, apply [patch](https://github.com/slominskir/wildfly-elytron/releases/tag/v1.19.1.Patch1) |
+| EMAIL_FROM         | Default from address for the mail/jlab resource                                                      |
+| EMAIL_HOST         | Host for the mail/jlab resource                                                                      |
+| EMAIL_PORT         | Port for the mail/jlab resource                                                                      |
+| GZIP               | If defined, enable gzip                                                                              |
+| KEYSTORE_NAME      | If defined, set TLS keystore name (file must be inside configuration dir and of type PKS12)          |
+| KEYSTORE_PASS      | Keystore password                                                                                    |
+| ORACLE_DRIVER_URL  | Path to ORACLE Driver for Wildfly to use                                                             |
+| MARIADB_DRIVER_URL | Path to MariaDB Driver for Wildfly to use                                                            |
+| WILDFLY_HOME       | Path to Wildfly home dir                                                                             | 
+| WILDFLY_PASS       | Admin password (if empty no admin user is created)                                                   |
+| WILDFLY_RUN_USER   | User for running Wildfly                                                                             | 
+| WILDFLY_USER       | Admin username (if empty no admin user is created)                                                   |
 
 **Note**: There is a self-signed test certificate installed, but you can override with your own cert by mounting a custom PKS12 keystore file to `/opt/jboss/wildfly/standalone/configuration/server.p12`  
 
@@ -59,6 +60,11 @@ Must be executed once per app installed in Wildfly.
 | ORACLE_SERVICE      | Oracle Service name to use to connect to DB from Wildfly                 | NO                  |
 | ORACLE_USER         | Username to use to connect to DB from Wildfly                            | NO                  |
 | ORACLE_PASS         | Password to use to connect to DB from Wildfly                            | NO                  |
+| MARIADB_DATASOURCE  | Name of MariaDB datasource (app key)                                     | NO                  |
+| MARIADB_SERVER      | Host name and port of MariaDB server used to connect to DB from Wildfly  | NO                  |
+| MARIADB_DB_NAME     | Name of MariaDB database name to use to connect from Wildfly             | NO                  |
+| MARIADB_USER        | Username to use to connect to DB from Wildfly                            | NO                  |
+| MARIADB_PASS        | Password to use to connect to DB from Wildfly                            | NO                  |
 | WILDFLY_HOME        | Path to Wildfly home dir                                                 | NO                  |
 | WILDFLY_RUN_USER    | User for running Wildfly                                                 | NO                  |
 
@@ -76,13 +82,20 @@ docker cp demo:/opt/jboss/wildfly .
 
 These environment variables are Docker specific and are used by the [docker-entrypoint.sh](https://github.com/JeffersonLab/wildfly/blob/main/scripts/docker-entrypoint.sh) script to wait on the Oracle database to start.
 
-| Name                | Description                                                                                     |
-|---------------------|-------------------------------------------------------------------------------------------------|
-| ORACLE_DATASOURCE   | Oracle Datasource name to use to connect to DB from TestOracleConnection utility                |
-| ORACLE_SERVER       | Host name and port of Oracle server to use to connect to DB from TestOracleConnection utility   |
-| ORACLE_USER         | Username to use to connect to DB from TestOracleConnection utility                              |
-| ORACLE_PASS         | Password to use to connect to DB from TestOracleConnection utility                              |
-| ORACLE_SERVICE      | Oracle Service name to use to connect to DB from TestOracleConnection utility                   |           
+| Name               | Description                                                                                   |
+|--------------------|-----------------------------------------------------------------------------------------------|
+| ORACLE_DATASOURCE  | Oracle Datasource name to use to connect to DB from TestOracleConnection utility              |
+| ORACLE_SERVER      | Host name and port of Oracle server to use to connect to DB from TestOracleConnection utility |
+| ORACLE_USER        | Username to use to connect to DB from TestOracleConnection utility                            |
+| ORACLE_PASS        | Password to use to connect to DB from TestOracleConnection utility                            |
+| ORACLE_SERVICE     | Oracle Service name to use to connect to DB from TestOracleConnection utility                 |           
+| MARIADB_DATASOURCE | MariaDB datasource name to use to connect to DB from TestMariaDBConnection utility            |
+| MARIADB_SERVER     | Host name and port of MariaDB server used to connect to DB from TestMariaDBConnection utility |
+| MARIADB_USER       | Username to use to connect to DB from TestMariaDBConnection utility                           |
+| MARIADB_PASS       | Password to use to connect to DB from TestMariaDBConnection utility                           |
+| MARIADB_DB_NANE    | MariaDB Service name to use to connect to DB from TestMariaDBConnection utility               |           
+
+**Note**: The entrypoint script waits for either an Oracle or a MariaDB database to start but not both.  Oracle takes precedence.
 
 ## Release
 1. Create a new release on the GitHub Releases page.  The release should enumerate changes and link issues.

--- a/README.md
+++ b/README.md
@@ -20,28 +20,28 @@ Wildfly must be pre-configured before the first deployment of an app.  The bash 
 
 Create a `.env` file for your environment and call the bash scripts [server-setup.sh](https://github.com/JeffersonLab/wildfly/blob/main/scripts/server-setup.sh) (example: [docker config](https://github.com/JeffersonLab/wildfly/blob/main/config/docker-server.env)) and [app-setup.sh](https://github.com/JeffersonLab/wildfly/blob/main/scripts/app-setup.sh) (example: [demo docker config](https://github.com/JeffersonLab/smoothness/blob/main/docker/demo/smoothness-demo-setup.env)) to do the initial Wildfly configuration.   Bash can be executed on Linux, Windows (WSL2), and Mac with some perseverance.  See [bash setup scripts](https://github.com/JeffersonLab/wildfly/tree/main/scripts).
 
-**Note**: If you are using Windows and WSL2 you may need to run dos2unix on .env and .sh files
+**Note**: If you are using Windows and WSL2 you may need to run `dos2unix` on .env and .sh files
 
 ### Server Setup 
 Only needs to be executed once per permanent installation of Wildfly.
 
-| Name               | Description                                                                                          |
-|--------------------|------------------------------------------------------------------------------------------------------|
-| ACCESS_LOG         | If defined, enable access logging                                                                    |
-| ADD_JBOSS_MODULES  | JBoss Modules to install, if any                                                                     |
-| APPLY_ELTRON_PATCH | If defined, apply [patch](https://github.com/slominskir/wildfly-elytron/releases/tag/v1.19.1.Patch1) |
-| EMAIL_FROM         | Default from address for the mail/jlab resource                                                      |
-| EMAIL_HOST         | Host for the mail/jlab resource                                                                      |
-| EMAIL_PORT         | Port for the mail/jlab resource                                                                      |
-| GZIP               | If defined, enable gzip                                                                              |
-| KEYSTORE_NAME      | If defined, set TLS keystore name (file must be inside configuration dir and of type PKS12)          |
-| KEYSTORE_PASS      | Keystore password                                                                                    |
-| ORACLE_DRIVER_URL  | Path to ORACLE Driver for Wildfly to use                                                             |
-| MARIADB_DRIVER_URL | Path to MariaDB Driver for Wildfly to use                                                            |
-| WILDFLY_HOME       | Path to Wildfly home dir                                                                             | 
-| WILDFLY_PASS       | Admin password (if empty no admin user is created)                                                   |
-| WILDFLY_RUN_USER   | User for running Wildfly                                                                             | 
-| WILDFLY_USER       | Admin username (if empty no admin user is created)                                                   |
+| Name                | Description                                                                                          |
+|---------------------|------------------------------------------------------------------------------------------------------|
+| ACCESS_LOG          | If defined, enable access logging                                                                    |
+| ADD_JBOSS_MODULES   | JBoss Modules to install, if any                                                                     |
+| APPLY_ELYTRON_PATCH | If defined, apply [patch](https://github.com/slominskir/wildfly-elytron/releases/tag/v1.19.1.Patch1) |
+| EMAIL_FROM          | Default from address for the mail/jlab resource                                                      |
+| EMAIL_HOST          | Host for the mail/jlab resource                                                                      |
+| EMAIL_PORT          | Port for the mail/jlab resource                                                                      |
+| GZIP                | If defined, enable gzip                                                                              |
+| KEYSTORE_NAME       | If defined, set TLS keystore name (file must be inside configuration dir and of type PKS12)          |
+| KEYSTORE_PASS       | Keystore password                                                                                    |
+| ORACLE_DRIVER_URL   | Path to ORACLE Driver for Wildfly to use                                                             |
+| MARIADB_DRIVER_URL  | Path to MariaDB Driver for Wildfly to use                                                            |
+| WILDFLY_HOME        | Path to Wildfly home dir                                                                             | 
+| WILDFLY_PASS        | Admin password (if empty no admin user is created)                                                   |
+| WILDFLY_RUN_USER    | User for running Wildfly                                                                             | 
+| WILDFLY_USER        | Admin username (if empty no admin user is created)                                                   |
 
 **Note**: There is a self-signed test certificate installed, but you can override with your own cert by mounting a custom PKS12 keystore file to `/opt/jboss/wildfly/standalone/configuration/server.p12`  
 
@@ -68,9 +68,9 @@ Must be executed once per app installed in Wildfly.
 | WILDFLY_HOME        | Path to Wildfly home dir                                                 | NO                  |
 | WILDFLY_RUN_USER    | User for running Wildfly                                                 | NO                  |
 
-**Note**: Runtime Overridable parameters only make sense for Wildfly instances used for a single app (such as in a Container).  Providing runtime overrides to a multi-app configuration would overrwrite all app configs of the same name.  See https://github.com/JeffersonLab/wildfly/blob/86df35a1357b5ad863ecc53be94676bf96ef8489/scripts/app-setup.sh#L69
+**Note**: Runtime Overridable parameters only make sense for Wildfly instances used for a single app (such as in a Container).  Providing runtime overrides to a multi-app configuration would overwrite all app configs of the same name.  See https://github.com/JeffersonLab/wildfly/blob/86df35a1357b5ad863ecc53be94676bf96ef8489/scripts/app-setup.sh#L69
 
-**Note**: As an alternative to the bash scripts The docker image configures Wildfly for use in the compose environment and that's a good starting point to copy from.  Outside of a compose environment you may need to tweak the standalone.xml configuration to use different host names and ports (For example Oracle and Keycloak host names would need to be updated to localhost:1521 and localhost:8081 respectively when using the deps.yml and running Wildfly outside the compose network):
+**Note**: As an alternative to the bash scripts The docker image configures Wildfly for use in the compose environment and that's a good starting point to copy from.  Outside a compose environment you may need to tweak the standalone.xml configuration to use different host names and ports (For example Oracle and Keycloak host names would need to be updated to localhost:1521 and localhost:8081 respectively when using the deps.yml and running Wildfly outside the compose network):
 
 ```
 docker compose up

--- a/config/docker-server.env
+++ b/config/docker-server.env
@@ -1,4 +1,5 @@
 ORACLE_DRIVER_URL=https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc11/21.7.0.0/ojdbc11-21.7.0.0.jar
+MARIADB_DRIVER_URL=https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/3.3.3/mariadb-java-client-3.3.3.jar
 WILDFLY_APP_HOME=/opt/jboss/wildfly
 WILDFLY_RUN_USER=jboss
 WILDFLY_PASS=admin

--- a/scripts/TestMariadbConnection.java
+++ b/scripts/TestMariadbConnection.java
@@ -1,0 +1,28 @@
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.sql.SQLException;
+
+
+public class TestMariadbConnection {
+    public static void testConnection(String connectionUrl) throws ClassNotFoundException, SQLException {
+        Class.forName("org.mariadb.jdbc.Driver");
+        try (
+        Connection con = DriverManager.getConnection(connectionUrl);
+        Statement stmt = con.createStatement()
+        ) {
+            stmt.executeQuery("SELECT 1 FROM DUAL");
+        }
+    }
+
+    public static void main(String[] args) {
+        try {
+            testConnection(args[0]);
+        } catch (Throwable t) {
+            if (args.length > 1 && "true".equals(args[1])) {
+                t.printStackTrace();
+            }
+            System.exit(-1);
+        }
+    }
+}

--- a/scripts/app-setup.sh
+++ b/scripts/app-setup.sh
@@ -3,6 +3,7 @@
 FUNCTIONS=(wildfly_start_and_wait
            config_keycloak_client
            config_oracle_client
+           config_mariadb_client
            wildfly_reload
            wildfly_stop)
 
@@ -44,6 +45,11 @@ done
 # - ORACLE_SERVER
 # - ORACLE_SERVICE
 # - ORACLE_USER
+# - MARIADB_DATASOURCE
+# - MARIADB_PASS
+# - MARIADB_SERVER
+# - MARIADB_DB_NAME
+# - MARIADB_USER
 # - WILDFLY_SKIP_START
 # - WILDFLY_SKIP_STOP
 
@@ -97,6 +103,19 @@ fi
 ${WILDFLY_CLI_PATH} -c <<EOF
 batch
 data-source add --name=jdbc/${ORACLE_DATASOURCE} --driver-name=oracle --jndi-name=java:/jdbc/${ORACLE_DATASOURCE} --connection-url=jdbc:oracle:thin:@//${ORACLE_SERVER}/${ORACLE_SERVICE} --user-name=${ORACLE_USER} --password=${ORACLE_PASS} --max-pool-size=3 --min-pool-size=1 --flush-strategy=EntirePool --use-fast-fail=true --blocking-timeout-wait-millis=5000 --query-timeout=30 --idle-timeout-minutes=5 --background-validation=true --background-validation-millis=30000 --validate-on-match=false --check-valid-connection-sql="select 1 from dual" --prepared-statements-cache-size=10 --share-prepared-statements=true
+run-batch
+EOF
+}
+
+config_mariadb_client() {
+if [[ -z "${MARIADB_DATASOURCE}" ]]; then
+  echo "Skipping config_mariadb_client because MARIADB_DATASOURCE undefined"
+  return 0
+fi
+
+${WILDFLY_CLI_PATH} -c <<EOF
+batch
+data-source add --name=jdbc/${MARIADB_DATASOURCE} --driver-name=mariadb --jndi-name=java:/jdbc/${MARIADB_DATASOURCE} --connection-url=jdbc:mariadb://${MARIADB_SERVER}/${MARIADB_DB_NAME} --user-name=${MARIADB_USER} --password=${MARIADB_PASS} --max-pool-size=3 --min-pool-size=1 --flush-strategy=EntirePool --use-fast-fail=true --blocking-timeout-wait-millis=5000 --query-timeout=30 --idle-timeout-minutes=5 --background-validation=true --background-validation-millis=30000 --validate-on-match=false --check-valid-connection-sql="select 1 from dual" --prepared-statements-cache-size=10 --share-prepared-statements=true
 run-batch
 EOF
 }

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 echo "----------------------------------------------------"
-echo "| Step 1: Waiting for Oracle DB to start listening |"
+echo "| Step 1: Waiting for Database to start listening  |"
 echo "----------------------------------------------------"
 if [[ -n ${ORACLE_USER} && -n ${ORACLE_PASS} && -n ${ORACLE_SERVER} && -n ${ORACLE_SERVICE} && -n ${ORACLE_DRIVER_PATH} ]]; then
-
+  echo "Detected Oracle config.  Attempting to connect."
   until java -cp "/:${ORACLE_DRIVER_PATH}" \
         /TestOracleConnection.java "jdbc:oracle:thin:${ORACLE_USER}/${ORACLE_PASS}@${ORACLE_SERVER}/${ORACLE_SERVICE}" "${DB_DEBUG}"
   do
@@ -13,6 +13,18 @@ if [[ -n ${ORACLE_USER} && -n ${ORACLE_PASS} && -n ${ORACLE_SERVER} && -n ${ORAC
   done
 
   echo $(date) " Oracle connection successful!"
+
+elif [[ -n ${MARIADB_USER} && -n ${MARIADB_PASS} && -n ${MARIADB_SERVER} && -n ${MARIADB_DB_NAME} && -n ${MARIADB_DRIVER_PATH} ]]; then
+  echo "Detected MariaDB config.  Attempting to connect."
+  until java -cp "/:${MARIADB_DRIVER_PATH}" \
+        /TestMariadbConnection.java "jdbc:mariadb://${MARIADB_SERVER}/${MARIADB_DB_NAME}?user=${MARIADB_USER}&password=${MARIADB_PASS}" "${DB_DEBUG}"
+  do
+    echo $(date) " Still waiting for MariaDB to start..."
+    sleep 5
+  done
+
+  echo $(date) " MariaDB connection successful!"
+
 else
   echo $(date) " Skipping DB Wait"
 fi

--- a/scripts/server-setup.sh
+++ b/scripts/server-setup.sh
@@ -3,6 +3,7 @@
 FUNCTIONS=(apply_elytron_patch
            wildfly_start_and_wait
            config_oracle_driver
+           config_mariadb_driver
            config_access_log
            config_admin_user
            config_ssl
@@ -55,6 +56,8 @@ done
 # - EMAIL_PORT
 # - ORACLE_DRIVER_PATH
 # - ORACLE_DRIVER_URL
+# - MARIADB_DRIVER_PATH
+# - MARIADB_DRIVER_URL
 # - WILDFLY_USER
 # - WILDFLY_PASS
 # - WILDFLY_SKIP_START
@@ -92,6 +95,24 @@ ${WILDFLY_CLI_PATH} -c <<EOF
 batch
 module add --name=com.oracle.database.jdbc --resources=${ORACLE_DRIVER_PATH} --dependencies=javax.api,javax.transaction.api
 /subsystem=datasources/jdbc-driver=oracle:add(driver-name=oracle,driver-module-name=com.oracle.database.jdbc)
+run-batch
+EOF
+}
+
+config_mariadb_driver() {
+echo "Configuring mariadb_driver"
+if [[ -z "${MARIADB_DRIVER_PATH}" ]]; then
+    echo "Skipping MariaDB Driver Setup: Must provide MARIADB_DRIVER_PATH in environment"
+    return 0
+fi
+
+echo wget -O "${MARIADB_DRIVER_PATH}" "${MARIADB_DRIVER_URL}"
+wget -O "${MARIADB_DRIVER_PATH}" "${MARIADB_DRIVER_URL}"
+
+${WILDFLY_CLI_PATH} -c <<EOF
+batch
+module add --name=org.mariadb.jdbc --resources=${MARIADB_DRIVER_PATH} --dependencies=javax.api,javax.transaction.api
+/subsystem=datasources/jdbc-driver=mariadb:add(driver-name=mariadb,driver-module-name=org.mariadb.jdbc)
 run-batch
 EOF
 }


### PR DESCRIPTION
I've added support for a MariaDB database similar to Oracle.

I did not require that only one database be configured, but left a comment that the general expectation is for a single database to configured.  In theory, I do not see why only one database would have to be used.  But I don't see their to be a need to prohibit users from doing so.  On quick reflection, the current entry-point script only waits for one database.  Perhaps I should update that to wait for both if they both exist?

I also made a few minor edits/fixes in the README.md.